### PR TITLE
Add basic navbar and home page

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,8 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -1,8 +1,15 @@
 import React, { useState } from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import RegisterPage from './pages/RegisterPage.jsx';
-import ReviewerForm from './components/ReviewerForm.jsx';
+import HomePage from './pages/HomePage.jsx';
+import DashboardPage from './pages/DashboardPage.jsx';
+import CategoriesPage from './pages/CategoriesPage.jsx';
+import BudgetsPage from './pages/BudgetsPage.jsx';
+import ExpensesPage from './pages/ExpensesPage.jsx';
+import AlertsPage from './pages/AlertsPage.jsx';
+import ReviewersPage from './pages/ReviewersPage.jsx';
 
 function Content() {
   const { user } = useAuth();
@@ -17,10 +24,17 @@ function Content() {
   }
 
   return (
-    <div>
-      <h1>Welcome, {user.username}</h1>
-      <ReviewerForm />
-    </div>
+    <Router>
+      <Routes>
+        <Route path='/' element={<HomePage />} />
+        <Route path='/dashboard' element={<DashboardPage />} />
+        <Route path='/categories' element={<CategoriesPage />} />
+        <Route path='/budgets' element={<BudgetsPage />} />
+        <Route path='/expenses' element={<ExpensesPage />} />
+        <Route path='/alerts' element={<AlertsPage />} />
+        <Route path='/reviewers' element={<ReviewersPage />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function Navbar() {
+  const { logout } = useAuth();
+
+  const linkClass = 'px-3 py-2 hover:underline';
+
+  return (
+    <nav className='bg-surface text-gray-200 p-4 flex space-x-4'>
+      <Link to='/' className={linkClass}>Inicio</Link>
+      <Link to='/dashboard' className={linkClass}>Dashboard</Link>
+      <Link to='/categories' className={linkClass}>Categorías</Link>
+      <Link to='/budgets' className={linkClass}>Presupuestos</Link>
+      <Link to='/expenses' className={linkClass}>Gastos</Link>
+      <Link to='/alerts' className={linkClass}>Alertas</Link>
+      <Link to='/reviewers' className={linkClass}>Revisores</Link>
+      <button onClick={logout} className={linkClass}>Salir</button>
+    </nav>
+  );
+}

--- a/front/src/pages/AlertsPage.jsx
+++ b/front/src/pages/AlertsPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Navbar from '../components/Navbar.jsx';
+
+export default function AlertsPage() {
+  return (
+    <div>
+      <Navbar />
+      <div className='p-4'>Alertas próximamente.</div>
+    </div>
+  );
+}

--- a/front/src/pages/BudgetsPage.jsx
+++ b/front/src/pages/BudgetsPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Navbar from '../components/Navbar.jsx';
+
+export default function BudgetsPage() {
+  return (
+    <div>
+      <Navbar />
+      <div className='p-4'>Presupuestos próximamente.</div>
+    </div>
+  );
+}

--- a/front/src/pages/CategoriesPage.jsx
+++ b/front/src/pages/CategoriesPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Navbar from '../components/Navbar.jsx';
+
+export default function CategoriesPage() {
+  return (
+    <div>
+      <Navbar />
+      <div className='p-4'>Categorías próximamente.</div>
+    </div>
+  );
+}

--- a/front/src/pages/DashboardPage.jsx
+++ b/front/src/pages/DashboardPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Navbar from '../components/Navbar.jsx';
+
+export default function DashboardPage() {
+  return (
+    <div>
+      <Navbar />
+      <div className='p-4'>Dashboard próximamente.</div>
+    </div>
+  );
+}

--- a/front/src/pages/ExpensesPage.jsx
+++ b/front/src/pages/ExpensesPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Navbar from '../components/Navbar.jsx';
+
+export default function ExpensesPage() {
+  return (
+    <div>
+      <Navbar />
+      <div className='p-4'>Gastos próximamente.</div>
+    </div>
+  );
+}

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Navbar from '../components/Navbar.jsx';
+
+export default function HomePage() {
+  return (
+    <div>
+      <Navbar />
+      <div className='p-4'>Bienvenido a Australiapp.</div>
+    </div>
+  );
+}

--- a/front/src/pages/ReviewersPage.jsx
+++ b/front/src/pages/ReviewersPage.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Navbar from '../components/Navbar.jsx';
+import ReviewerForm from '../components/ReviewerForm.jsx';
+
+export default function ReviewersPage() {
+  return (
+    <div>
+      <Navbar />
+      <div className='p-4'>
+        <h2 className='text-xl mb-4'>Agregar Revisor</h2>
+        <ReviewerForm />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- implement `Navbar` component
- add placeholder pages for dashboard, budgets, categories, expenses, alerts and reviewers
- show a new `HomePage` after login with navigation links
- wire routes in `App.jsx`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857ad2fb92c832595d0fd34ef673856