### PR TITLE
Add homepage with navbar

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import RegisterPage from './pages/RegisterPage.jsx';
-import ReviewerForm from './components/ReviewerForm.jsx';
+import HomePage from './pages/HomePage.jsx';
 
 function Content() {
   const { user } = useAuth();
@@ -16,12 +16,7 @@ function Content() {
     );
   }
 
-  return (
-    <div>
-      <h1>Welcome, {user.username}</h1>
-      <ReviewerForm />
-    </div>
-  );
+  return <HomePage />;
 }
 
 export default function App() {

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Navbar({ onNavigate, onLogout }) {
+  return (
+    <nav className='bg-[#1e1e1e] text-gray-200 p-4 flex items-center gap-4'>
+      <button
+        className='hover:underline'
+        onClick={() => onNavigate('home')}
+      >
+        Inicio
+      </button>
+      <button
+        className='hover:underline'
+        onClick={() => onNavigate('reviewer')}
+      >
+        Revisores
+      </button>
+      <div className='flex-grow'></div>
+      <button className='hover:underline' onClick={onLogout}>
+        Cerrar sesión
+      </button>
+    </nav>
+  );
+}
+
+Navbar.propTypes = {
+  onNavigate: PropTypes.func.isRequired,
+  onLogout: PropTypes.func.isRequired,
+};

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext.jsx';
+import ReviewerForm from '../components/ReviewerForm.jsx';
+import Navbar from '../components/Navbar.jsx';
+
+export default function HomePage() {
+  const { user, logout } = useAuth();
+  const [view, setView] = useState('home');
+
+  let content = (
+    <div className='p-4'>Bienvenido, {user.username}</div>
+  );
+  if (view === 'reviewer') {
+    content = (
+      <div className='p-4'>
+        <h2 className='text-xl mb-4'>Agregar revisor</h2>
+        <ReviewerForm />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Navbar onNavigate={setView} onLogout={logout} />
+      {content}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Navbar` component with navigation and logout
- add `HomePage` that displays a navbar and optional reviewer form
- show `HomePage` after login instead of the bare reviewer form

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857b25764348325a30b00de9f0b6e91