### PR TITLE
Add category budget creation

### DIFF
--- a/back/controllers/categorias.controller.js
+++ b/back/controllers/categorias.controller.js
@@ -1,0 +1,10 @@
+import { createCategoryWithBudgets } from '../services/categoriaService.js';
+
+export async function createCategory(req, res) {
+  try {
+    const category = await createCategoryWithBudgets(req.body);
+    res.json(category);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/back/index.js
+++ b/back/index.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { testConnection, sequelize } from './config/index.js';
 import authRoutes from './routes/auth.routes.js';
 import reviewerRoutes from './routes/reviewers.routes.js';
+import categoryRoutes from './routes/categorias.routes.js';
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // Rutas
 app.use('/api/auth', authRoutes);
 app.use('/api/reviewers', reviewerRoutes);
+app.use('/api/categories', categoryRoutes);
 
 async function start() {
   await testConnection();

--- a/back/routes/categorias.routes.js
+++ b/back/routes/categorias.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { createCategory } from '../controllers/categorias.controller.js';
+
+const router = Router();
+
+router.post('/', createCategory);
+
+export default router;

--- a/back/services/categoriaService.js
+++ b/back/services/categoriaService.js
@@ -1,0 +1,40 @@
+import { Categoria } from '../models/categoria.model.js';
+import { Presupuesto } from '../models/presupuesto.model.js';
+
+/**
+ * Crea una categoría junto con sus presupuestos asociados.
+ * @param {Object} data
+ * @param {string} data.name
+ * @param {string} [data.description]
+ * @param {boolean} data.recurring
+ * @param {string} [data.recurrence_end_date] - YYYY-MM-DD si es recurrente
+ * @param {Array<{amount:number,period_month:number,period_year:number}>} data.budgets
+ */
+export async function createCategoryWithBudgets({
+  name,
+  description,
+  recurring = false,
+  recurrence_end_date = null,
+  budgets = [],
+}) {
+  if (!name) {
+    throw new Error('Name is required');
+  }
+  if (!Array.isArray(budgets) || budgets.length === 0) {
+    throw new Error('At least one budget entry is required');
+  }
+  const category = await Categoria.create({ name, description });
+
+  const records = budgets.map((b) => ({
+    category_id: category.id,
+    amount: b.amount,
+    period_month: b.period_month,
+    period_year: b.period_year,
+    recurring,
+    recurrence_end_date: recurring ? recurrence_end_date : null,
+  }));
+
+  await Presupuesto.bulkCreate(records);
+
+  return category.toJSON();
+}

--- a/front/src/components/CategoryForm.jsx
+++ b/front/src/components/CategoryForm.jsx
@@ -1,0 +1,216 @@
+import React, { useState } from 'react';
+import CustomInput from './CustomInput.jsx';
+import CustomButton from './CustomButton.jsx';
+import { createCategory } from '../services/api.js';
+
+export default function CategoryForm() {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [type, setType] = useState('variable'); // 'variable' or 'recurring'
+  const [entries, setEntries] = useState([
+    { amount: '', month: '', year: '' },
+  ]);
+  const [recAmount, setRecAmount] = useState('');
+  const [recStartMonth, setRecStartMonth] = useState('');
+  const [recStartYear, setRecStartYear] = useState('');
+  const [recEndMonth, setRecEndMonth] = useState('');
+  const [recEndYear, setRecEndYear] = useState('');
+  const [message, setMessage] = useState(null);
+  const [error, setError] = useState(null);
+
+  const handleEntryChange = (index, field, value) => {
+    setEntries((prev) =>
+      prev.map((e, i) => (i === index ? { ...e, [field]: value } : e))
+    );
+  };
+
+  const addEntry = () => {
+    setEntries((prev) => [...prev, { amount: '', month: '', year: '' }]);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    try {
+      let payload;
+      if (type === 'variable') {
+        const budgets = entries.map((e) => ({
+          amount: Number(e.amount),
+          period_month: Number(e.month),
+          period_year: Number(e.year),
+        }));
+        payload = { name, description, recurring: false, budgets };
+      } else {
+        const budgets = [
+          {
+            amount: Number(recAmount),
+            period_month: Number(recStartMonth),
+            period_year: Number(recStartYear),
+          },
+        ];
+        const endDate = `${recEndYear}-${String(recEndMonth).padStart(2, '0')}-01`;
+        payload = {
+          name,
+          description,
+          recurring: true,
+          recurrence_end_date: endDate,
+          budgets,
+        };
+      }
+      await createCategory(payload);
+      setMessage('Categoría creada');
+      setName('');
+      setDescription('');
+      setEntries([{ amount: '', month: '', year: '' }]);
+      setRecAmount('');
+      setRecStartMonth('');
+      setRecStartYear('');
+      setRecEndMonth('');
+      setRecEndYear('');
+    } catch (err) {
+      console.error(err);
+      setError('No se pudo crear');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      {error && <p className='text-red-500 mb-2'>{error}</p>}
+      {message && <p className='text-green-500 mb-2'>{message}</p>}
+      <CustomInput
+        name='name'
+        id='cat-name'
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder='Nombre'
+        required
+      >
+        Nombre
+      </CustomInput>
+      <CustomInput
+        name='description'
+        id='cat-desc'
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder='Descripción'
+      >
+        Descripción
+      </CustomInput>
+      <div className='my-4'>
+        <label className='block text-sm font-medium text-white-700'>Tipo</label>
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className='mt-1 block w-full p-2 border-b-2 border-gray-300 bg-transparent text-white'
+        >
+          <option value='variable' className='text-black'>Variable por mes</option>
+          <option value='recurring' className='text-black'>Mismo cada mes</option>
+        </select>
+      </div>
+      {type === 'variable' ? (
+        <div>
+          {entries.map((entry, i) => (
+            <div key={i} className='border p-2 mb-2'>
+              <CustomInput
+                name={`amount-${i}`}
+                id={`amount-${i}`}
+                value={entry.amount}
+                onChange={(e) => handleEntryChange(i, 'amount', e.target.value)}
+                placeholder='Monto'
+                inputMode='decimal'
+                required
+              >
+                Monto
+              </CustomInput>
+              <CustomInput
+                name={`month-${i}`}
+                id={`month-${i}`}
+                value={entry.month}
+                onChange={(e) => handleEntryChange(i, 'month', e.target.value)}
+                placeholder='Mes (1-12)'
+                inputMode='numeric'
+                required
+              >
+                Mes
+              </CustomInput>
+              <CustomInput
+                name={`year-${i}`}
+                id={`year-${i}`}
+                value={entry.year}
+                onChange={(e) => handleEntryChange(i, 'year', e.target.value)}
+                placeholder='Año'
+                inputMode='numeric'
+                required
+              >
+                Año
+              </CustomInput>
+            </div>
+          ))}
+          <CustomButton type='button' onClick={addEntry}>Añadir mes</CustomButton>
+        </div>
+      ) : (
+        <div className='border p-2 mb-2'>
+          <CustomInput
+            name='rec-amount'
+            id='rec-amount'
+            value={recAmount}
+            onChange={(e) => setRecAmount(e.target.value)}
+            placeholder='Monto'
+            inputMode='decimal'
+            required
+          >
+            Monto mensual
+          </CustomInput>
+          <CustomInput
+            name='rec-start-month'
+            id='rec-start-month'
+            value={recStartMonth}
+            onChange={(e) => setRecStartMonth(e.target.value)}
+            placeholder='Mes inicio'
+            inputMode='numeric'
+            required
+          >
+            Mes inicio
+          </CustomInput>
+          <CustomInput
+            name='rec-start-year'
+            id='rec-start-year'
+            value={recStartYear}
+            onChange={(e) => setRecStartYear(e.target.value)}
+            placeholder='Año inicio'
+            inputMode='numeric'
+            required
+          >
+            Año inicio
+          </CustomInput>
+          <CustomInput
+            name='rec-end-month'
+            id='rec-end-month'
+            value={recEndMonth}
+            onChange={(e) => setRecEndMonth(e.target.value)}
+            placeholder='Mes fin'
+            inputMode='numeric'
+            required
+          >
+            Mes fin
+          </CustomInput>
+          <CustomInput
+            name='rec-end-year'
+            id='rec-end-year'
+            value={recEndYear}
+            onChange={(e) => setRecEndYear(e.target.value)}
+            placeholder='Año fin'
+            inputMode='numeric'
+            required
+          >
+            Año fin
+          </CustomInput>
+        </div>
+      )}
+      <CustomButton type='submit' isPrimary>
+        Guardar
+      </CustomButton>
+    </form>
+  );
+}

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -16,6 +16,12 @@ export default function Navbar({ onNavigate, onLogout }) {
       >
         Revisores
       </button>
+      <button
+        className='hover:underline'
+        onClick={() => onNavigate('category')}
+      >
+        Categorías
+      </button>
       <div className='flex-grow'></div>
       <button className='hover:underline' onClick={onLogout}>
         Cerrar sesión

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../context/AuthContext.jsx';
 import ReviewerForm from '../components/ReviewerForm.jsx';
+import CategoryForm from '../components/CategoryForm.jsx';
 import Navbar from '../components/Navbar.jsx';
 
 export default function HomePage() {
@@ -15,6 +16,13 @@ export default function HomePage() {
       <div className='p-4'>
         <h2 className='text-xl mb-4'>Agregar revisor</h2>
         <ReviewerForm />
+      </div>
+    );
+  } else if (view === 'category') {
+    content = (
+      <div className='p-4'>
+        <h2 className='text-xl mb-4'>Agregar categoría</h2>
+        <CategoryForm />
       </div>
     );
   }

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -1,5 +1,6 @@
 const API_URL = '/api/auth';
 const REVIEWER_URL = '/api/reviewers';
+const CATEGORY_URL = '/api/categories';
 
 export async function registerUser(data) {
   const res = await fetch(`${API_URL}/register`, {
@@ -28,5 +29,15 @@ export async function addReviewer(data) {
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error('Failed to add reviewer');
+  return res.json();
+}
+
+export async function createCategory(data) {
+  const res = await fetch(CATEGORY_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create category');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- implement category creation service
- add categories route and controller
- expose API endpoint in backend index
- create React form for categories
- update navbar and homepage to access new form
- expand API helper with category request

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858a0f5fd7c8325aa6e06d739443345