### PR TITLE
Implement category budgets

### DIFF
--- a/back/controllers/categorias.controller.js
+++ b/back/controllers/categorias.controller.js
@@ -1,0 +1,10 @@
+import { createCategoryWithBudget } from '../services/categoriaService.js';
+
+export async function createCategoria(req, res) {
+  try {
+    const categoria = await createCategoryWithBudget(req.body);
+    res.json(categoria);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/back/index.js
+++ b/back/index.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { testConnection, sequelize } from './config/index.js';
 import authRoutes from './routes/auth.routes.js';
 import reviewerRoutes from './routes/reviewers.routes.js';
+import categoriaRoutes from './routes/categorias.routes.js';
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // Rutas
 app.use('/api/auth', authRoutes);
 app.use('/api/reviewers', reviewerRoutes);
+app.use('/api/categorias', categoriaRoutes);
 
 async function start() {
   await testConnection();

--- a/back/routes/categorias.routes.js
+++ b/back/routes/categorias.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { createCategoria } from '../controllers/categorias.controller.js';
+
+const router = Router();
+
+router.post('/', createCategoria);
+
+export default router;

--- a/back/services/categoriaService.js
+++ b/back/services/categoriaService.js
@@ -1,0 +1,56 @@
+import { sequelize } from '../config/index.js';
+import { Categoria } from '../models/categoria.model.js';
+import { Presupuesto } from '../models/presupuesto.model.js';
+
+export async function createCategoryWithBudget(data) {
+  const { name, description, recurring } = data;
+  return sequelize.transaction(async (t) => {
+    const category = await Categoria.create({ name, description }, { transaction: t });
+
+    if (recurring) {
+      const { amount, start_month, start_year, end_month, end_year } = data;
+      if (
+        amount == null ||
+        start_month == null ||
+        start_year == null ||
+        end_month == null ||
+        end_year == null
+      ) {
+        throw new Error('Missing fields for recurring budget');
+      }
+      const endDate = new Date(Number(end_year), Number(end_month) - 1, 1);
+      await Presupuesto.create(
+        {
+          category_id: category.id,
+          amount,
+          period_month: Number(start_month),
+          period_year: Number(start_year),
+          recurring: true,
+          recurrence_end_date: endDate,
+        },
+        { transaction: t }
+      );
+    } else {
+      if (!Array.isArray(data.budgets) || data.budgets.length === 0) {
+        throw new Error('No budgets provided');
+      }
+      for (const b of data.budgets) {
+        const { amount, month, year } = b;
+        if (amount == null || month == null || year == null) {
+          throw new Error('Invalid budget entry');
+        }
+        await Presupuesto.create(
+          {
+            category_id: category.id,
+            amount,
+            period_month: Number(month),
+            period_year: Number(year),
+            recurring: false,
+          },
+          { transaction: t }
+        );
+      }
+    }
+    return category.toJSON();
+  });
+}

--- a/front/src/components/CategoryForm.jsx
+++ b/front/src/components/CategoryForm.jsx
@@ -1,0 +1,225 @@
+import React, { useState } from 'react';
+import CustomInput from './CustomInput.jsx';
+import CustomButton from './CustomButton.jsx';
+import CustomSelect from './CustomSelect.jsx';
+import { createCategory } from '../services/api.js';
+
+const months = [
+  '1','2','3','4','5','6','7','8','9','10','11','12'
+];
+
+export default function CategoryForm() {
+  const currentYear = new Date().getFullYear();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [recurring, setRecurring] = useState(true);
+  const [amount, setAmount] = useState('');
+  const [startMonth, setStartMonth] = useState('1');
+  const [startYear, setStartYear] = useState(String(currentYear));
+  const [endMonth, setEndMonth] = useState('12');
+  const [endYear, setEndYear] = useState(String(currentYear));
+  const [budgets, setBudgets] = useState([
+    { month: '1', year: String(currentYear), amount: '' },
+  ]);
+  const [message, setMessage] = useState(null);
+  const [error, setError] = useState(null);
+
+  const handleAddMonth = () => {
+    const last = budgets[budgets.length - 1];
+    let m = Number(last.month) + 1;
+    let y = Number(last.year);
+    if (m > 12) {
+      m = 1;
+      y += 1;
+    }
+    setBudgets([...budgets, { month: String(m), year: String(y), amount: '' }]);
+  };
+
+  const handleBudgetChange = (idx, field, value) => {
+    setBudgets((prev) =>
+      prev.map((b, i) => (i === idx ? { ...b, [field]: value } : b))
+    );
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+
+    try {
+      let payload;
+      if (recurring) {
+        payload = {
+          name,
+          description,
+          recurring: true,
+          amount: parseFloat(amount),
+          start_month: Number(startMonth),
+          start_year: Number(startYear),
+          end_month: Number(endMonth),
+          end_year: Number(endYear),
+        };
+      } else {
+        payload = {
+          name,
+          description,
+          recurring: false,
+          budgets: budgets.map((b) => ({
+            month: Number(b.month),
+            year: Number(b.year),
+            amount: parseFloat(b.amount),
+          })),
+        };
+      }
+      await createCategory(payload);
+      setMessage('Categoría creada');
+      // reset form
+      setName('');
+      setDescription('');
+      setAmount('');
+      setBudgets([{ month: '1', year: String(currentYear), amount: '' }]);
+    } catch (err) {
+      console.error(err);
+      setError('No se pudo crear la categoría');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      {error && <p className='text-red-500 mb-2'>{error}</p>}
+      {message && <p className='text-green-500 mb-2'>{message}</p>}
+      <CustomInput
+        name='name'
+        id='name'
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder='Nombre de categoría'
+        required
+      >
+        Nombre
+      </CustomInput>
+      <CustomInput
+        name='description'
+        id='description'
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder='Descripción opcional'
+      >
+        Descripción
+      </CustomInput>
+      <div className='my-4'>
+        <label className='flex items-center gap-2'>
+          <input
+            type='checkbox'
+            checked={recurring}
+            onChange={(e) => setRecurring(e.target.checked)}
+          />
+          <span>Presupuesto recurrente</span>
+        </label>
+      </div>
+      {recurring ? (
+        <>
+          <CustomInput
+            name='amount'
+            id='amount'
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder='Monto'
+            inputMode='decimal'
+            required
+          >
+            Monto mensual
+          </CustomInput>
+          <div className='flex gap-4'>
+            <CustomSelect
+              name='startMonth'
+              id='startMonth'
+              value={startMonth}
+              onChange={(e) => setStartMonth(e.target.value)}
+              options={months}
+            >
+              Mes inicio
+            </CustomSelect>
+            <CustomInput
+              name='startYear'
+              id='startYear'
+              value={startYear}
+              onChange={(e) => setStartYear(e.target.value)}
+              inputMode='numeric'
+              required
+            >
+              Año inicio
+            </CustomInput>
+          </div>
+          <div className='flex gap-4'>
+            <CustomSelect
+              name='endMonth'
+              id='endMonth'
+              value={endMonth}
+              onChange={(e) => setEndMonth(e.target.value)}
+              options={months}
+            >
+              Mes fin
+            </CustomSelect>
+            <CustomInput
+              name='endYear'
+              id='endYear'
+              value={endYear}
+              onChange={(e) => setEndYear(e.target.value)}
+              inputMode='numeric'
+              required
+            >
+              Año fin
+            </CustomInput>
+          </div>
+        </>
+      ) : (
+        <>
+          {budgets.map((b, idx) => (
+            <div key={idx} className='border p-2 mb-2'>
+              <CustomInput
+                name={`amount-${idx}`}
+                id={`amount-${idx}`}
+                value={b.amount}
+                onChange={(e) => handleBudgetChange(idx, 'amount', e.target.value)}
+                placeholder='Monto'
+                inputMode='decimal'
+                required
+              >
+                Monto
+              </CustomInput>
+              <div className='flex gap-4'>
+                <CustomSelect
+                  name={`month-${idx}`}
+                  id={`month-${idx}`}
+                  value={b.month}
+                  onChange={(e) => handleBudgetChange(idx, 'month', e.target.value)}
+                  options={months}
+                >
+                  Mes
+                </CustomSelect>
+                <CustomInput
+                  name={`year-${idx}`}
+                  id={`year-${idx}`}
+                  value={b.year}
+                  onChange={(e) => handleBudgetChange(idx, 'year', e.target.value)}
+                  inputMode='numeric'
+                  required
+                >
+                  Año
+                </CustomInput>
+              </div>
+            </div>
+          ))}
+          <CustomButton type='button' onClick={handleAddMonth}>
+            Agregar mes
+          </CustomButton>
+        </>
+      )}
+      <CustomButton type='submit' isPrimary>
+        Guardar
+      </CustomButton>
+    </form>
+  );
+}
+

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -16,6 +16,12 @@ export default function Navbar({ onNavigate, onLogout }) {
       >
         Revisores
       </button>
+      <button
+        className='hover:underline'
+        onClick={() => onNavigate('category')}
+      >
+        Categorías
+      </button>
       <div className='flex-grow'></div>
       <button className='hover:underline' onClick={onLogout}>
         Cerrar sesión

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../context/AuthContext.jsx';
 import ReviewerForm from '../components/ReviewerForm.jsx';
+import CategoryForm from '../components/CategoryForm.jsx';
 import Navbar from '../components/Navbar.jsx';
 
 export default function HomePage() {
@@ -15,6 +16,14 @@ export default function HomePage() {
       <div className='p-4'>
         <h2 className='text-xl mb-4'>Agregar revisor</h2>
         <ReviewerForm />
+      </div>
+    );
+  }
+  if (view === 'category') {
+    content = (
+      <div className='p-4'>
+        <h2 className='text-xl mb-4'>Nueva categoría</h2>
+        <CategoryForm />
       </div>
     );
   }

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -1,5 +1,6 @@
 const API_URL = '/api/auth';
 const REVIEWER_URL = '/api/reviewers';
+const CATEGORY_URL = '/api/categorias';
 
 export async function registerUser(data) {
   const res = await fetch(`${API_URL}/register`, {
@@ -28,5 +29,15 @@ export async function addReviewer(data) {
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error('Failed to add reviewer');
+  return res.json();
+}
+
+export async function createCategory(data) {
+  const res = await fetch(CATEGORY_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create category');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add service and controller logic to create a category with budgets
- expose new `/api/categorias` endpoint from the backend
- implement React form to create categories with recurring or per‑month budgets
- hook new page and option into navbar
- extend frontend API helper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858a0f5fd7c8325aa6e06d739443345