### PR TITLE
Load currencies from API

### DIFF
--- a/back/controllers/divisas.controller.js
+++ b/back/controllers/divisas.controller.js
@@ -1,0 +1,10 @@
+import { getAllDivisaCodes } from '../services/divisaService.js';
+
+export async function listDivisaCodes(req, res) {
+  try {
+    const codes = await getAllDivisaCodes();
+    res.json(codes);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/back/index.js
+++ b/back/index.js
@@ -5,6 +5,7 @@ import authRoutes from './routes/auth.routes.js';
 import reviewerRoutes from './routes/reviewers.routes.js';
 import categoriaRoutes from './routes/categorias.routes.js';
 import usuarioRoutes from './routes/usuarios.routes.js';
+import divisaRoutes from './routes/divisas.routes.js';
 
 const app = express();
 app.use(cors());
@@ -15,6 +16,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/reviewers', reviewerRoutes);
 app.use('/api/categorias', categoriaRoutes);
 app.use('/api/users', usuarioRoutes);
+app.use('/api/divisas', divisaRoutes);
 
 async function start() {
   await testConnection();

--- a/back/routes/divisas.routes.js
+++ b/back/routes/divisas.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { listDivisaCodes } from '../controllers/divisas.controller.js';
+
+const router = Router();
+
+router.get('/', listDivisaCodes);
+
+export default router;

--- a/back/services/divisaService.js
+++ b/back/services/divisaService.js
@@ -1,0 +1,6 @@
+import { Divisa } from '../models/divisa.model.js';
+
+export async function getAllDivisaCodes() {
+  const divisas = await Divisa.findAll({ attributes: ['code'], order: [['code', 'ASC']] });
+  return divisas.map((d) => d.code);
+}

--- a/front/src/components/CategoryForm.jsx
+++ b/front/src/components/CategoryForm.jsx
@@ -3,6 +3,7 @@ import CustomInput from './CustomInput.jsx';
 import CustomButton from './CustomButton.jsx';
 import CustomSelect from './CustomSelect.jsx';
 import { createCategory } from '../services/api.js';
+import useCurrencies from '../hooks/useCurrencies.js';
 
 const months = [
   '1','2','3','4','5','6','7','8','9','10','11','12'
@@ -14,7 +15,8 @@ export default function CategoryForm() {
   const [description, setDescription] = useState('');
   const [recurring, setRecurring] = useState(true);
   const [amount, setAmount] = useState('');
-  const [currency, setCurrency] = useState('USD');
+  const currencies = useCurrencies();
+  const [currency, setCurrency] = useState('');
   const [startMonth, setStartMonth] = useState('1');
   const [startYear, setStartYear] = useState(String(currentYear));
   const [endMonth, setEndMonth] = useState('12');
@@ -24,6 +26,12 @@ export default function CategoryForm() {
   ]);
   const [message, setMessage] = useState(null);
   const [error, setError] = useState(null);
+
+  React.useEffect(() => {
+    if (!currency && currencies.length > 0) {
+      setCurrency(currencies[0]);
+    }
+  }, [currencies]);
 
   const handleAddMonth = () => {
     const last = budgets[budgets.length - 1];
@@ -80,7 +88,7 @@ export default function CategoryForm() {
       setName('');
       setDescription('');
       setAmount('');
-      setCurrency('USD');
+      setCurrency(currencies[0] ?? '');
       setBudgets([{ month: '1', year: String(currentYear), amount: '' }]);
     } catch (err) {
       console.error(err);
@@ -126,7 +134,7 @@ export default function CategoryForm() {
         id='currency'
         value={currency}
         onChange={(e) => setCurrency(e.target.value)}
-        options={['USD', 'AUD', 'MXN']}
+        options={currencies}
         required
       >
         Divisa del presupuesto

--- a/front/src/components/CategoryForm.jsx
+++ b/front/src/components/CategoryForm.jsx
@@ -31,7 +31,7 @@ export default function CategoryForm() {
     if (!currency && currencies.length > 0) {
       setCurrency(currencies[0]);
     }
-  }, [currencies]);
+  }, [currencies, currency]);
 
   const handleAddMonth = () => {
     const last = budgets[budgets.length - 1];

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import useCurrencies from '../hooks/useCurrencies.js';
 
 export default function Navbar({ onNavigate, onLogout, currency, onCurrencyChange }) {
   const [open, setOpen] = useState(false);
+  const currencies = useCurrencies();
   return (
     <nav className='bg-[#1e1e1e] text-gray-200 p-4 flex items-center gap-4'>
       <button
@@ -35,9 +37,11 @@ export default function Navbar({ onNavigate, onLogout, currency, onCurrencyChang
               value={currency}
               onChange={(e) => onCurrencyChange(e.target.value)}
             >
-              <option value='USD'>USD</option>
-              <option value='AUD'>AUD</option>
-              <option value='MXN'>MXN</option>
+              {currencies.map((code) => (
+                <option key={code} value={code}>
+                  {code}
+                </option>
+              ))}
             </select>
             <button
               className='w-full text-left hover:underline'

--- a/front/src/hooks/useCurrencies.js
+++ b/front/src/hooks/useCurrencies.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { fetchCurrencies } from '../services/api.js';
+
+export default function useCurrencies() {
+  const [currencies, setCurrencies] = useState([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    fetchCurrencies()
+      .then((data) => {
+        if (isMounted) setCurrencies(data);
+      })
+      .catch((err) => console.error(err));
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return currencies;
+}

--- a/front/src/pages/RegisterPage.jsx
+++ b/front/src/pages/RegisterPage.jsx
@@ -6,11 +6,19 @@ import CustomSelect from '../components/CustomSelect.jsx';
 import CustomButton from '../components/CustomButton.jsx';
 import AuthCardError from '../components/auth/AuthCardError.jsx';
 import { FaUser, FaLock, FaMoneyBill } from 'react-icons/fa';
+import useCurrencies from '../hooks/useCurrencies.js';
 
 export default function RegisterPage({ onSwitch }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [currency, setCurrency] = useState('USD');
+  const currencies = useCurrencies();
+  const [currency, setCurrency] = useState('');
+
+  React.useEffect(() => {
+    if (!currency && currencies.length > 0) {
+      setCurrency(currencies[0]);
+    }
+  }, [currencies]);
   const { register } = useAuth();
   const [error, setError] = useState(null);
 
@@ -61,7 +69,7 @@ export default function RegisterPage({ onSwitch }) {
           id='reg-currency'
           value={currency}
           onChange={(e) => setCurrency(e.target.value)}
-          options={['USD', 'AUD', 'MXN']}
+          options={currencies}
           icon={<FaMoneyBill />}
           required
         >

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -2,6 +2,7 @@ const API_URL = '/api/auth';
 const REVIEWER_URL = '/api/reviewers';
 const CATEGORY_URL = '/api/categorias';
 const USER_URL = '/api/users';
+const DIVISA_URL = '/api/divisas';
 
 export async function registerUser(data) {
   const res = await fetch(`${API_URL}/register`, {
@@ -50,5 +51,11 @@ export async function updateUserCurrency(userId, code) {
     body: JSON.stringify({ code }),
   });
   if (!res.ok) throw new Error('Failed to update currency');
+  return res.json();
+}
+
+export async function fetchCurrencies() {
+  const res = await fetch(DIVISA_URL);
+  if (!res.ok) throw new Error('Failed to fetch currencies');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add API endpoints to list currencies from the database
- fetch currencies from the frontend
- display database currencies in RegisterPage, CategoryForm and Navbar

## Testing
- `npm test` in `back` *(fails: Error: no test specified)*
- `npm run lint` in `front`

------
https://chatgpt.com/codex/tasks/task_e_6858b71f1b78832592ad20988ead8654