### PR TITLE
Integrate Material Web components

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -8,31 +8,14 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-      integrity="sha512-bdP3jUNhI63QwIvl0Y12hL4APkEacAdzTZziEtGlUZEM6I4vGU+mLjxJvPBhOtJk9HB+11FXGeUXrXe3zD7ukw=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
     />
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            fontFamily: { sans: ['Inter', 'sans-serif'] },
-            colors: {
-              primary: '#2196f3',
-              accent: '#90caf9',
-              surface: '#1e1e1e',
-              background: '#121212',
-            },
-          },
-        },
-      };
-    </script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@material/web@1.0/all.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="font-sans bg-[#121212] text-gray-200">

--- a/front/src/components/CustomButton.jsx
+++ b/front/src/components/CustomButton.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 /**
- * Componente de botón personalizado.
+ * Material 3 button component using Material Web 1.0.
  */
 export default function CustomButton({
   type = 'button',
@@ -10,22 +10,16 @@ export default function CustomButton({
   onClick,
   children,
 }) {
-  const primaryClasses =
-    'w-full bg-[#2196f3] text-white py-2 px-4 mb-4 rounded-md hover:bg-[#1976d2] transition duration-200 cursor-pointer';
-  const secondaryClasses =
-    'w-full bg-[#1e1e1e] text-gray-200 py-2 px-4 mb-4 rounded-md border border-gray-600 hover:bg-[#2c2c2c] transition duration-200 cursor-pointer';
-  const disabledClasses =
-    'w-full bg-gray-500 text-white py-2 px-4 mb-4 rounded-md cursor-not-allowed';
-
+  const Tag = isPrimary ? 'md-filled-button' : 'md-outlined-button';
   return (
-    <button
+    <Tag
       type={type}
-      onClick={onClick}
-      className={disabled ? disabledClasses : isPrimary ? primaryClasses : secondaryClasses}
       disabled={disabled}
+      onClick={onClick}
+      className='w-full mb-4'
     >
       {children}
-    </button>
+    </Tag>
   );
 }
 

--- a/front/src/components/CustomInput.jsx
+++ b/front/src/components/CustomInput.jsx
@@ -34,46 +34,36 @@ export default function CustomInput({
 }) {
   const [showPassword, setShowPassword] = useState(false);
 
+  const Tag = 'md-outlined-text-field';
+
   return (
     <div className='my-4'>
-      <label htmlFor={id} className='block text-sm font-medium text-white-700'>
-        <div className='flex justify-between items-center w-full'>
-          <span>{children}</span>
-          {type === 'password' && (
-            <button
-              type='button'
-              onClick={() => setShowPassword((p) => !p)}
-              className='text-sm text-[#2196f3] hover:underline ml-2'
-            >
-              {showPassword ? 'Ocultar' : 'Mostrar'}
-            </button>
-          )}
-        </div>
-      </label>
-      <div className='relative'>
-        {icon && (
-          <span className='absolute left-2 top-1/2 -translate-y-1/2 text-gray-500'>
-            {icon}
-          </span>
+      <Tag
+        name={name}
+        id={id}
+        type={type === 'password' && showPassword ? 'text' : type}
+        label={String(children)}
+        placeholder={placeholder}
+        maxlength={maxLength}
+        required={required}
+        value={value}
+        inputMode={inputMode}
+        pattern={pattern}
+        onInput={onChange}
+        className='w-full'
+      >
+        {icon && <span slot='leading-icon'>{icon}</span>}
+        {type === 'password' && (
+          <md-icon-button
+            slot='trailing-icon'
+            onClick={() => setShowPassword((p) => !p)}
+          >
+            <span className='material-symbols-outlined'>
+              {showPassword ? 'visibility_off' : 'visibility'}
+            </span>
+          </md-icon-button>
         )}
-        <input
-          name={name}
-          id={id}
-          type={type === 'password' && showPassword ? 'text' : type}
-          placeholder={placeholder}
-          maxLength={maxLength}
-          required={required}
-          onChange={onChange}
-          value={value}
-          inputMode={inputMode}
-          pattern={pattern}
-          className={`mt-1 block w-full p-2 border-b-2 ${
-            icon ? 'pl-8' : ''
-          } ${
-            errorMessage ? 'border-red-500' : 'border-gray-300'
-          } focus:border-[#2196f3] focus:ring-[#2196f3] placeholder:text-gray-400 placeholder:text-sm`}
-        />
-      </div>
+      </Tag>
       {errorMessage && <p className='mt-1 text-sm text-red-600'>{errorMessage}</p>}
     </div>
   );

--- a/front/src/components/CustomSelect.jsx
+++ b/front/src/components/CustomSelect.jsx
@@ -12,39 +12,31 @@ export default function CustomSelect({
 }) {
   return (
     <div className='my-4'>
-      <label htmlFor={id} className='block text-sm font-medium text-white-700'>
-        {children}
-      </label>
-      <div className='relative'>
-        {icon && (
-          <span className='absolute left-2 top-1/2 -translate-y-1/2 text-gray-500'>
-            {icon}
-          </span>
-        )}
-        <select
-          name={name}
-          id={id}
-          value={value}
-          onChange={onChange}
-          required={required}
-          className={`mt-1 block w-full p-2 border-b-2 ${icon ? 'pl-8' : ''} border-gray-300 focus:border-[#2196f3] focus:ring-[#2196f3] bg-transparent text-white`}
-        >
-          {options.map((opt) => {
-            if (typeof opt === 'object') {
-              return (
-                <option key={opt.value} value={opt.value} className='text-black'>
-                  {opt.label}
-                </option>
-              );
-            }
+      <md-outlined-select
+        label={String(children)}
+        name={name}
+        id={id}
+        value={value}
+        onInput={onChange}
+        required={required}
+        className='w-full'
+      >
+        {icon && <span slot='leading-icon'>{icon}</span>}
+        {options.map((opt) => {
+          if (typeof opt === 'object') {
             return (
-              <option key={opt} value={opt} className='text-black'>
-                {opt}
-              </option>
+              <md-select-option key={opt.value} value={opt.value}>
+                {opt.label}
+              </md-select-option>
             );
-          })}
-        </select>
-      </div>
+          }
+          return (
+            <md-select-option key={opt} value={opt}>
+              {opt}
+            </md-select-option>
+          );
+        })}
+      </md-outlined-select>
     </div>
   );
 }

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -6,53 +6,47 @@ export default function Navbar({ onNavigate, onLogout, currency, onCurrencyChang
   const [open, setOpen] = useState(false);
   const currencies = useCurrencies();
   return (
-    <nav className='bg-[#1e1e1e] text-gray-200 p-4 flex items-center gap-4'>
-      <button
-        className='hover:underline'
-        onClick={() => onNavigate('home')}
-      >
-        Inicio
-      </button>
-      <button
-        className='hover:underline'
-        onClick={() => onNavigate('reviewer')}
-      >
-        Revisores
-      </button>
-      <button
-        className='hover:underline'
-        onClick={() => onNavigate('category')}
-      >
-        Categorías
-      </button>
-      <div className='flex-grow'></div>
-      <div className='relative'>
-        <button className='hover:underline' onClick={() => setOpen(!open)}>
-          Perfil
-        </button>
-        {open && (
-          <div className='absolute right-0 mt-2 w-40 bg-white text-black rounded shadow-md p-2'>
-            <select
-              className='w-full mb-2 border p-1'
-              value={currency}
-              onChange={(e) => onCurrencyChange(e.target.value)}
-            >
-              {currencies.map((code) => (
-                <option key={code} value={code}>
-                  {code}
-                </option>
-              ))}
-            </select>
-            <button
-              className='w-full text-left hover:underline'
-              onClick={onLogout}
-            >
-              Cerrar sesión
-            </button>
-          </div>
-        )}
-      </div>
-    </nav>
+    <>
+      <md-top-app-bar>
+        <md-icon-button slot='navigationIcon' onClick={() => setOpen(!open)}>
+          <span className='material-symbols-outlined'>menu</span>
+        </md-icon-button>
+        <div slot='title'>Australiapp</div>
+        <md-icon-button slot='actionItems' onClick={onLogout}>
+          <span className='material-symbols-outlined'>logout</span>
+        </md-icon-button>
+      </md-top-app-bar>
+      {open && (
+        <div className='p-4'>
+          <md-elevation></md-elevation>
+          <md-list>
+            <md-list-item onClick={() => { onNavigate('home'); setOpen(false); }}>
+              Inicio
+            </md-list-item>
+            <md-list-item onClick={() => { onNavigate('reviewer'); setOpen(false); }}>
+              Revisores
+            </md-list-item>
+            <md-list-item onClick={() => { onNavigate('category'); setOpen(false); }}>
+              Categorías
+            </md-list-item>
+            <md-list-item>
+              <md-outlined-select
+                value={currency}
+                label='Moneda'
+                onInput={(e) => onCurrencyChange(e.target.value)}
+                className='w-full'
+              >
+                {currencies.map((code) => (
+                  <md-select-option key={code} value={code}>
+                    {code}
+                  </md-select-option>
+                ))}
+              </md-outlined-select>
+            </md-list-item>
+          </md-list>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/front/src/components/auth/AuthCard.jsx
+++ b/front/src/components/auth/AuthCard.jsx
@@ -25,30 +25,20 @@ export default function AuthCard({
         p-4 bg-[#121212] relative overflow-hidden
       "
     >
-      <div
-        className="
-          w-full max-w-lg
-          rounded-lg overflow-hidden shadow-lg relative z-10 bg-[#1e1e1e]
-        "
-      >
+      <md-filled-card class="w-full max-w-lg relative z-10">
         <div className="flex flex-col w-full h-full p-6 sm:p-8 md:p-10">
           {showBackButton && (
             <div className="mb-4">
               <BackButton onClick={onBack} className="cursor-pointer" />
             </div>
           )}
-          <h1
-            className="
-              text-2xl sm:text-3xl font-semibold
-              text-gray-100 mb-2 font-serif
-            "
-          >
+          <h1 className="text-2xl sm:text-3xl font-semibold mb-2 font-serif">
             {title}
           </h1>
-          <p className="mb-4 text-gray-300 text-sm sm:text-base">{description}</p>
+          <p className="mb-4 text-sm sm:text-base">{description}</p>
           {children}
         </div>
-      </div>
+      </md-filled-card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- switch to Roboto and Material Symbols fonts
- load Material Web 1.0 library
- implement Material buttons, text fields and selects
- replace auth card container with `md-filled-card`
- revamp navbar with `md-top-app-bar`

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858bf01f7748325842f684c000ce321