### PR TITLE
Improve color palette

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -22,9 +22,13 @@
             fontFamily: { sans: ['Roboto', 'sans-serif'] },
             colors: {
               primary: '#2196f3',
+              onPrimary: '#ffffff',
               accent: '#90caf9',
               surface: '#1e1e1e',
+              onSurface: '#e0e0e0',
               background: '#121212',
+              onBackground: '#e0e0e0',
+              error: '#f44336',
             },
           },
         },
@@ -32,7 +36,7 @@
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="font-sans bg-[#121212] text-gray-200">
+  <body class="font-sans bg-background text-onBackground">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/front/src/components/BackButton.jsx
+++ b/front/src/components/BackButton.jsx
@@ -9,7 +9,7 @@ export default function BackButton({ onClick, className = '' }) {
     <button
       type='button'
       onClick={onClick}
-      className={`flex items-center text-[#2196f3] hover:underline ${className}`}
+      className={`flex items-center text-primary hover:underline ${className}`}
     >
       <span className='mr-1'>&larr;</span>
       Regresar

--- a/front/src/components/CategoryForm.jsx
+++ b/front/src/components/CategoryForm.jsx
@@ -109,8 +109,8 @@ export default function CategoryForm() {
 
   return (
     <form onSubmit={handleSubmit} noValidate>
-      {error && <p className='text-red-500 mb-2'>{error}</p>}
-      {message && <p className='text-green-500 mb-2'>{message}</p>}
+      {error && <p className='text-error mb-2'>{error}</p>}
+      {message && <p className='text-accent mb-2'>{message}</p>}
       <CustomInput
         name='name'
         id='name'

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -12,7 +12,7 @@ export default function Navbar({ onNavigate, onLogout, currency, onCurrencyChang
   const [open, setOpen] = useState(false);
   const currencies = useCurrencies();
   return (
-    <nav className='bg-[#1e1e1e] text-gray-200 p-4 flex items-center gap-4'>
+    <nav className='bg-surface text-onSurface p-4 flex items-center gap-4'>
       <button
         className='hover:underline'
         onClick={() => onNavigate('home')}
@@ -37,7 +37,7 @@ export default function Navbar({ onNavigate, onLogout, currency, onCurrencyChang
           <md-icon>account_circle</md-icon>
         </md-icon-button>
         {open && (
-          <div className='absolute right-0 mt-2 w-40 bg-[#1e1e1e] text-white rounded shadow-md p-2'>
+          <div className='absolute right-0 mt-2 w-40 bg-surface text-onSurface rounded shadow-md p-2'>
             <md-outlined-select
               className='w-full mb-2'
               value={currency}

--- a/front/src/components/ReviewerForm.jsx
+++ b/front/src/components/ReviewerForm.jsx
@@ -30,8 +30,8 @@ export default function ReviewerForm() {
 
   return (
     <form onSubmit={handleSubmit} noValidate>
-      {error && <p className='text-red-500 mb-2'>{error}</p>}
-      {message && <p className='text-green-500 mb-2'>{message}</p>}
+      {error && <p className='text-error mb-2'>{error}</p>}
+      {message && <p className='text-accent mb-2'>{message}</p>}
       <CustomInput
         name='reviewer'
         id='reviewer'

--- a/front/src/components/auth/AuthCard.jsx
+++ b/front/src/components/auth/AuthCard.jsx
@@ -22,13 +22,13 @@ export default function AuthCard({
     <div
       className="
         flex justify-center items-center w-full min-h-screen
-        p-4 bg-[#121212] relative overflow-hidden
+        p-4 bg-background relative overflow-hidden
       "
     >
       <div
         className="
           w-full max-w-lg
-          rounded-lg overflow-hidden shadow-lg relative z-10 bg-[#1e1e1e]
+          rounded-lg overflow-hidden shadow-lg relative z-10 bg-surface text-onSurface
         "
       >
         <div className="flex flex-col w-full h-full p-6 sm:p-8 md:p-10">
@@ -40,12 +40,12 @@ export default function AuthCard({
           <h1
             className="
               text-2xl sm:text-3xl font-semibold
-              text-gray-100 mb-2 font-serif
+              text-onSurface mb-2 font-serif
             "
           >
             {title}
           </h1>
-          <p className="mb-4 text-gray-300 text-sm sm:text-base">{description}</p>
+          <p className="mb-4 text-onSurface/80 text-sm sm:text-base">{description}</p>
           {children}
         </div>
       </div>

--- a/front/src/components/auth/AuthCardError.jsx
+++ b/front/src/components/auth/AuthCardError.jsx
@@ -1,3 +1,3 @@
 export default function AuthCardError({ children }) {
-  return <p className='text-red-600 mb-2'>{children}</p>;
+  return <p className='text-error mb-2'>{children}</p>;
 }

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,9 +1,18 @@
+:root {
+  --md-primary: #2196f3;
+  --md-accent: #90caf9;
+  --md-surface: #1e1e1e;
+  --md-background: #121212;
+  --md-on-surface: #e0e0e0;
+  --md-on-background: #e0e0e0;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, sans-serif;
-  background-color: #121212;
-  color: #e0e0e0;
+  background-color: var(--md-background);
+  color: var(--md-on-background);
   min-height: 100vh;
 }
 

--- a/front/src/pages/LoginPage.jsx
+++ b/front/src/pages/LoginPage.jsx
@@ -74,12 +74,12 @@ export default function LoginPage({ onSwitch }) {
           />
           <span>Recuérdame</span>
         </label>
-        <p className='text-sm text-gray-600 mb-4'>
+        <p className='text-sm text-onSurface/80 mb-4'>
           ¿No tienes cuenta?{' '}
           <button
             type='button'
             onClick={onSwitch}
-            className='text-[#2196f3] hover:underline bg-transparent border-none cursor-pointer'
+            className='text-primary hover:underline bg-transparent border-none cursor-pointer'
           >
             Regístrate
           </button>


### PR DESCRIPTION
## Summary
- use CSS variables for material colors
- configure Tailwind with material colors
- apply the palette in components and pages
- use accent/error colors for messages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858c82757b88325865b2696d08194e9