### PR TITLE
Add expense registration tab

### DIFF
--- a/back/controllers/categorias.controller.js
+++ b/back/controllers/categorias.controller.js
@@ -1,4 +1,4 @@
-import { createCategoryWithBudget } from '../services/categoriaService.js';
+import { createCategoryWithBudget, listAllCategories } from '../services/categoriaService.js';
 
 export async function createCategoria(req, res) {
   try {
@@ -6,5 +6,14 @@ export async function createCategoria(req, res) {
     res.json(categoria);
   } catch (err) {
     res.status(400).json({ error: err.message });
+  }
+}
+
+export async function listCategorias(req, res) {
+  try {
+    const cats = await listAllCategories();
+    res.json(cats);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
   }
 }

--- a/back/controllers/gastos.controller.js
+++ b/back/controllers/gastos.controller.js
@@ -1,0 +1,11 @@
+import { createGasto } from '../services/gastoService.js';
+
+export async function create(req, res) {
+  try {
+    const gasto = await createGasto(req.body);
+    res.json(gasto);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+

--- a/back/index.js
+++ b/back/index.js
@@ -6,6 +6,7 @@ import reviewerRoutes from './routes/reviewers.routes.js';
 import categoriaRoutes from './routes/categorias.routes.js';
 import usuarioRoutes from './routes/usuarios.routes.js';
 import divisaRoutes from './routes/divisas.routes.js';
+import gastoRoutes from './routes/gastos.routes.js';
 
 const app = express();
 app.use(cors());
@@ -17,6 +18,7 @@ app.use('/api/reviewers', reviewerRoutes);
 app.use('/api/categorias', categoriaRoutes);
 app.use('/api/users', usuarioRoutes);
 app.use('/api/divisas', divisaRoutes);
+app.use('/api/gastos', gastoRoutes);
 
 async function start() {
   await testConnection();

--- a/back/routes/categorias.routes.js
+++ b/back/routes/categorias.routes.js
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import { createCategoria } from '../controllers/categorias.controller.js';
+import { createCategoria, listCategorias } from '../controllers/categorias.controller.js';
 
 const router = Router();
 
 router.post('/', createCategoria);
+router.get('/', listCategorias);
 
 export default router;

--- a/back/routes/gastos.routes.js
+++ b/back/routes/gastos.routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { create } from '../controllers/gastos.controller.js';
+
+const router = Router();
+
+router.post('/', create);
+
+export default router;
+

--- a/back/services/categoriaService.js
+++ b/back/services/categoriaService.js
@@ -57,3 +57,8 @@ export async function createCategoryWithBudget(data) {
     return category.toJSON();
   });
 }
+
+export async function listAllCategories() {
+  const cats = await Categoria.findAll({ attributes: ['id', 'name'], order: [['name', 'ASC']] });
+  return cats.map((c) => c.toJSON());
+}

--- a/back/services/gastoService.js
+++ b/back/services/gastoService.js
@@ -1,0 +1,31 @@
+import { Gasto } from '../models/gasto.model.js';
+
+export async function createGasto(data) {
+  const {
+    amount,
+    currency_code,
+    category_id,
+    date,
+    description,
+    recurring = false,
+    recurrence_type,
+    recurrence_end_date,
+  } = data;
+
+  if (amount == null || !currency_code || !category_id || !date) {
+    throw new Error('Missing required fields');
+  }
+
+  const gasto = await Gasto.create({
+    amount,
+    currency_code,
+    category_id,
+    date,
+    description,
+    recurring,
+    recurrence_type: recurring ? recurrence_type : null,
+    recurrence_end_date: recurring ? recurrence_end_date : null,
+  });
+  return gasto.toJSON();
+}
+

--- a/front/src/components/ExpenseForm.jsx
+++ b/front/src/components/ExpenseForm.jsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect } from 'react';
+import CustomInput from './CustomInput.jsx';
+import CustomSelect from './CustomSelect.jsx';
+import CustomButton from './CustomButton.jsx';
+import useCurrencies from '../hooks/useCurrencies.js';
+import useCategories from '../hooks/useCategories.js';
+import { createExpense } from '../services/api.js';
+
+export default function ExpenseForm() {
+  const currencies = useCurrencies();
+  const categories = useCategories();
+
+  const [amount, setAmount] = useState('');
+  const [currency, setCurrency] = useState('');
+  const [category, setCategory] = useState('');
+  const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
+  const [description, setDescription] = useState('');
+  const [recurring, setRecurring] = useState(false);
+  const [endDate, setEndDate] = useState('');
+  const [recurrenceType, setRecurrenceType] = useState('monthly');
+  const [message, setMessage] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!currency && currencies.length > 0) {
+      setCurrency(currencies[0]);
+    }
+    if (!category && categories.length > 0) {
+      setCategory(String(categories[0].id));
+    }
+  }, [currencies, categories]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    try {
+      const payload = {
+        amount: parseFloat(amount),
+        currency_code: currency,
+        category_id: Number(category),
+        date,
+        description,
+        recurring,
+      };
+      if (recurring) {
+        payload.recurrence_end_date = endDate;
+        payload.recurrence_type = recurrenceType;
+      }
+      await createExpense(payload);
+      setMessage('Gasto registrado');
+      setAmount('');
+      setDescription('');
+      setRecurring(false);
+      setEndDate('');
+    } catch (err) {
+      console.error(err);
+      setError('No se pudo registrar el gasto');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      {error && <p className='text-red-500 mb-2'>{error}</p>}
+      {message && <p className='text-green-500 mb-2'>{message}</p>}
+      <CustomInput
+        name='amount'
+        id='amount'
+        value={amount}
+        onChange={(e) => setAmount(e.target.value)}
+        placeholder='Monto'
+        inputMode='decimal'
+        required
+      >
+        Monto
+      </CustomInput>
+      <CustomSelect
+        name='currency'
+        id='currency'
+        value={currency}
+        onChange={(e) => setCurrency(e.target.value)}
+        options={currencies}
+        required
+      >
+        Divisa
+      </CustomSelect>
+      <CustomSelect
+        name='category'
+        id='category'
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+        options={categories.map((c) => ({ value: String(c.id), label: c.name }))}
+        required
+      >
+        Categoría
+      </CustomSelect>
+      <CustomInput
+        name='date'
+        id='date'
+        type='date'
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        required
+      >
+        Fecha
+      </CustomInput>
+      <CustomInput
+        name='description'
+        id='description'
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder='Descripción opcional'
+      >
+        Descripción
+      </CustomInput>
+      <div className='my-4'>
+        <label className='flex items-center gap-2'>
+          <input
+            type='checkbox'
+            checked={recurring}
+            onChange={(e) => setRecurring(e.target.checked)}
+          />
+          <span>Gasto recurrente</span>
+        </label>
+      </div>
+      {recurring && (
+        <>
+          <CustomInput
+            name='endDate'
+            id='endDate'
+            type='date'
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            required
+          >
+            Fecha fin
+          </CustomInput>
+          <CustomSelect
+            name='recurrenceType'
+            id='recurrenceType'
+            value={recurrenceType}
+            onChange={(e) => setRecurrenceType(e.target.value)}
+            options={[
+              { value: 'monthly', label: 'Mensual' },
+              { value: 'weekly', label: 'Semanal' },
+            ]}
+            required
+          >
+            Frecuencia
+          </CustomSelect>
+        </>
+      )}
+      <CustomButton type='submit' isPrimary>
+        Guardar
+      </CustomButton>
+    </form>
+  );
+}

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -31,6 +31,12 @@ export default function Navbar({ onNavigate, onLogout, currency, onCurrencyChang
       >
         Categorías
       </button>
+      <button
+        className='hover:underline'
+        onClick={() => onNavigate('expense')}
+      >
+        Registrar gasto
+      </button>
       <div className='flex-grow'></div>
       <div className='relative'>
         <md-icon-button onClick={() => setOpen(!open)}>

--- a/front/src/hooks/useCategories.js
+++ b/front/src/hooks/useCategories.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+import { fetchCategories } from '../services/api.js';
+
+export default function useCategories() {
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    fetchCategories()
+      .then((data) => {
+        if (isMounted) setCategories(data);
+      })
+      .catch((err) => console.error(err));
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return categories;
+}

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useAuth } from '../context/AuthContext.jsx';
 import ReviewerForm from '../components/ReviewerForm.jsx';
 import CategoryForm from '../components/CategoryForm.jsx';
+import ExpenseForm from '../components/ExpenseForm.jsx';
 import Navbar from '../components/Navbar.jsx';
 
 export default function HomePage() {
@@ -24,6 +25,14 @@ export default function HomePage() {
       <div className='p-4'>
         <h2 className='text-xl mb-4'>Nueva categoría</h2>
         <CategoryForm />
+      </div>
+    );
+  }
+  if (view === 'expense') {
+    content = (
+      <div className='p-4'>
+        <h2 className='text-xl mb-4'>Registrar gasto</h2>
+        <ExpenseForm />
       </div>
     );
   }

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -3,6 +3,7 @@ const REVIEWER_URL = '/api/reviewers';
 const CATEGORY_URL = '/api/categorias';
 const USER_URL = '/api/users';
 const DIVISA_URL = '/api/divisas';
+const GASTO_URL = '/api/gastos';
 
 export async function registerUser(data) {
   const res = await fetch(`${API_URL}/register`, {
@@ -44,6 +45,12 @@ export async function createCategory(data) {
   return res.json();
 }
 
+export async function fetchCategories() {
+  const res = await fetch(CATEGORY_URL);
+  if (!res.ok) throw new Error('Failed to fetch categories');
+  return res.json();
+}
+
 export async function updateUserCurrency(userId, code) {
   const res = await fetch(`${USER_URL}/${userId}/currency`, {
     method: 'PUT',
@@ -57,5 +64,15 @@ export async function updateUserCurrency(userId, code) {
 export async function fetchCurrencies() {
   const res = await fetch(DIVISA_URL);
   if (!res.ok) throw new Error('Failed to fetch currencies');
+  return res.json();
+}
+
+export async function createExpense(data) {
+  const res = await fetch(GASTO_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create expense');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add API route to list categories
- implement expenses API endpoint
- wire up expense creation service
- add React hooks/components for registering a new expense
- show new "Registrar gasto" tab in the UI

## Testing
- `npm run lint` in `front`
- `npm test` in `back` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68633befc21083258aa18930bac7e635