### PR TITLE
Implement dashboard with summary charts

### DIFF
--- a/back/controllers/reports.controller.js
+++ b/back/controllers/reports.controller.js
@@ -1,9 +1,20 @@
-import { getSummary } from '../services/reportService.js';
+import { getSummary, getCategoryDetail } from '../services/reportService.js';
 
 export async function summaryController(req, res) {
   const { range = 'month' } = req.query;
   try {
     const data = await getSummary(range);
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function categoryController(req, res) {
+  const { range = 'month' } = req.query;
+  const { id } = req.params;
+  try {
+    const data = await getCategoryDetail(id, range);
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/back/controllers/reports.controller.js
+++ b/back/controllers/reports.controller.js
@@ -1,4 +1,8 @@
-import { getSummary, getCategoryDetail } from '../services/reportService.js';
+import {
+  getSummary,
+  getCategoryDetail,
+  getHistoricalTable,
+} from '../services/reportService.js';
 
 export async function summaryController(req, res) {
   const { range = 'month' } = req.query;
@@ -15,6 +19,15 @@ export async function categoryController(req, res) {
   const { id } = req.params;
   try {
     const data = await getCategoryDetail(id, range);
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+export async function summaryTableController(req, res) {
+  try {
+    const data = await getHistoricalTable();
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/back/controllers/reports.controller.js
+++ b/back/controllers/reports.controller.js
@@ -1,0 +1,11 @@
+import { getSummary } from '../services/reportService.js';
+
+export async function summaryController(req, res) {
+  const { range = 'month' } = req.query;
+  try {
+    const data = await getSummary(range);
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/back/index.js
+++ b/back/index.js
@@ -7,6 +7,7 @@ import categoriaRoutes from './routes/categorias.routes.js';
 import usuarioRoutes from './routes/usuarios.routes.js';
 import divisaRoutes from './routes/divisas.routes.js';
 import gastoRoutes from './routes/gastos.routes.js';
+import reportRoutes from './routes/reports.routes.js';
 import { startRecurringExpenseJob } from './cron/recurringExpenses.js';
 import { startDivisaUpdateJob } from './cron/updateDivisas.js';
 
@@ -21,6 +22,7 @@ app.use('/api/categorias', categoriaRoutes);
 app.use('/api/users', usuarioRoutes);
 app.use('/api/divisas', divisaRoutes);
 app.use('/api/gastos', gastoRoutes);
+app.use('/api/reports', reportRoutes);
 
 async function start() {
   await testConnection();

--- a/back/routes/reports.routes.js
+++ b/back/routes/reports.routes.js
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import { summaryController } from '../controllers/reports.controller.js';
+import { summaryController, categoryController } from '../controllers/reports.controller.js';
 
 const router = Router();
 
 router.get('/summary', summaryController);
+router.get('/category/:id', categoryController);
 
 export default router;

--- a/back/routes/reports.routes.js
+++ b/back/routes/reports.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { summaryController } from '../controllers/reports.controller.js';
+
+const router = Router();
+
+router.get('/summary', summaryController);
+
+export default router;

--- a/back/routes/reports.routes.js
+++ b/back/routes/reports.routes.js
@@ -1,9 +1,14 @@
 import { Router } from 'express';
-import { summaryController, categoryController } from '../controllers/reports.controller.js';
+import {
+  summaryController,
+  categoryController,
+  summaryTableController,
+} from '../controllers/reports.controller.js';
 
 const router = Router();
 
 router.get('/summary', summaryController);
 router.get('/category/:id', categoryController);
+router.get('/summary-table', summaryTableController);
 
 export default router;

--- a/back/services/reportService.js
+++ b/back/services/reportService.js
@@ -1,0 +1,75 @@
+import { Categoria } from '../models/categoria.model.js';
+import { Presupuesto } from '../models/presupuesto.model.js';
+import { Gasto } from '../models/gasto.model.js';
+import { Op } from 'sequelize';
+
+function monthsBetween(start, end) {
+  return (
+    end.getFullYear() * 12 + end.getMonth() -
+    (start.getFullYear() * 12 + start.getMonth())
+  ) + 1;
+}
+
+export async function getSummary(range = 'month') {
+  const now = new Date();
+  let start;
+  let end = new Date();
+
+  switch (range) {
+    case 'week':
+      start = new Date(now);
+      start.setDate(start.getDate() - 7);
+      break;
+    case 'year':
+      start = new Date(now.getFullYear() - 1, now.getMonth() + 1, 1);
+      break;
+    case 'month':
+    default:
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
+      break;
+  }
+
+  const categories = await Categoria.findAll({ attributes: ['id', 'name'] });
+  const result = [];
+  let totalBudget = 0;
+  let totalExpenses = 0;
+
+  for (const cat of categories) {
+    const budgets = await Presupuesto.findAll({ where: { category_id: cat.id } });
+    let budget = 0;
+    for (const b of budgets) {
+      const recordStart = new Date(b.period_year, b.period_month - 1, 1);
+      if (b.recurring) {
+        const recEnd = b.recurrence_end_date || end;
+        if (recEnd >= start && end >= recordStart) {
+          const effectiveStart = start > recordStart ? start : recordStart;
+          const effectiveEnd = end < recEnd ? end : recEnd;
+          const months = monthsBetween(effectiveStart, effectiveEnd);
+          budget += months * parseFloat(b.amount);
+        }
+      } else {
+        if (recordStart >= start && recordStart <= end) {
+          budget += parseFloat(b.amount);
+        }
+      }
+    }
+
+    const expenses = await Gasto.sum('amount', {
+      where: {
+        category_id: cat.id,
+        date: { [Op.between]: [start, end] },
+      },
+    });
+
+    const spent = parseFloat(expenses || 0);
+    totalBudget += budget;
+    totalExpenses += spent;
+    result.push({ id: cat.id, name: cat.name, budget, expenses: spent });
+  }
+
+  return {
+    categories: result,
+    totalBudget,
+    totalExpenses,
+  };
+}

--- a/front/index.html
+++ b/front/index.html
@@ -15,22 +15,22 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
       rel="stylesheet"
     />
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            fontFamily: { sans: ['Roboto', 'sans-serif'] },
-            colors: {
-              primary: '#2196f3',
-              accent: '#90caf9',
-              surface: '#1e1e1e',
-              background: '#121212',
+      <script src="https://cdn.tailwindcss.com"></script>
+      <script>
+        tailwind.config = {
+          theme: {
+            extend: {
+              fontFamily: { sans: ['Roboto', 'sans-serif'] },
+              colors: {
+                primary: '#2196f3',
+                accent: '#90caf9',
+                surface: '#1e1e1e',
+                background: '#121212',
+              },
             },
           },
-        },
-      };
-    </script>
-    <script src="https://cdn.tailwindcss.com"></script>
+        };
+      </script>
   </head>
   <body class="font-sans bg-background text-gray-200">
     <div id="root"></div>

--- a/front/package.json
+++ b/front/package.json
@@ -12,9 +12,11 @@
   },
   "dependencies": {
     "@material/web": "^1.5.1",
+    "chart.js": "^4.5.0",
     "lit": "^3.3.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0"
   },

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -11,6 +11,7 @@ import {
 } from 'chart.js';
 import useReport from '../hooks/useReport.js';
 import useCategories from '../hooks/useCategories.js';
+import useSummaryTable from '../hooks/useSummaryTable.js';
 
 ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
@@ -25,6 +26,7 @@ export default function Dashboard() {
   const [range, setRange] = useState('month');
   const [category, setCategory] = useState('all');
   const report = useReport(range, category);
+  const table = useSummaryTable(category === 'all');
 
   if (!report) return <p className='p-4'>Cargando...</p>;
 
@@ -35,6 +37,9 @@ export default function Dashboard() {
 
   const makeColors = (n) =>
     Array.from({ length: n }, (_, i) => `hsl(${(i * 60) % 360},70%,60%)`);
+
+  const monthName = (m) =>
+    new Date(2000, m - 1, 1).toLocaleString('es', { month: 'short' }).toUpperCase();
 
   let content;
   if (category === 'all') {
@@ -185,6 +190,66 @@ export default function Dashboard() {
         </select>
       </div>
       {content}
+      {category === 'all' && table && (
+        <div className='overflow-x-auto mt-8'>
+          <table className='min-w-max text-sm border-collapse whitespace-nowrap'>
+            <thead>
+              <tr>
+                <th className='border px-2 whitespace-nowrap'>Rubros</th>
+                <th className='border px-2 whitespace-nowrap' colSpan={3}>Antes</th>
+                {table.months.map((m) => (
+                  <th
+                    key={`${m.year}-${m.month}`}
+                    className='border px-2 whitespace-nowrap'
+                    colSpan='3'
+                  >
+                    {monthName(m.month)} {m.year}
+                  </th>
+                ))}
+                <th className='border px-2 whitespace-nowrap' colSpan='2'>Total por rubro</th>
+              </tr>
+              <tr>
+                <th></th>
+                <th className='border px-2 whitespace-nowrap'>Mes</th>
+                <th className='border px-2 whitespace-nowrap'>Real</th>
+                <th className='border px-2 whitespace-nowrap'>Dif</th>
+                {table.months.map((m) => (
+                  <React.Fragment key={`h-${m.year}-${m.month}`}>
+                    <th className='border px-2 whitespace-nowrap'>Mes</th>
+                    <th className='border px-2 whitespace-nowrap'>Real</th>
+                    <th className='border px-2 whitespace-nowrap'>Dif</th>
+                  </React.Fragment>
+                ))}
+                <th className='border px-2 whitespace-nowrap'>Mes</th>
+                <th className='border px-2 whitespace-nowrap'>Real</th>
+              </tr>
+            </thead>
+            <tbody>
+              {table.categories.map((cat) => (
+                <tr key={cat.id}>
+                  <td className='border px-2 text-left whitespace-nowrap'>{cat.name}</td>
+                  <td className='border px-2 whitespace-nowrap'>{cat.antesBudget.toFixed(2)}</td>
+                  <td className='border px-2 whitespace-nowrap'>{cat.antesReal.toFixed(2)}</td>
+                  <td className='border px-2 whitespace-nowrap'>
+                    {(cat.antesBudget - cat.antesReal).toFixed(2)}
+                  </td>
+                  {cat.months.map((m, idx) => (
+                    <React.Fragment key={idx}>
+                      <td className='border px-2 whitespace-nowrap'>{m.budget.toFixed(2)}</td>
+                      <td className='border px-2 whitespace-nowrap'>{m.real.toFixed(2)}</td>
+                      <td className='border px-2 whitespace-nowrap'>
+                        {(m.budget - m.real).toFixed(2)}
+                      </td>
+                    </React.Fragment>
+                  ))}
+                  <td className='border px-2 whitespace-nowrap'>{cat.totalBudget.toFixed(2)}</td>
+                  <td className='border px-2 whitespace-nowrap'>{cat.totalReal.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -38,6 +38,7 @@ export default function Dashboard() {
 
   let content;
   if (category === 'all') {
+    if (!Array.isArray(report.categories)) return <p className='p-4'>Cargando...</p>;
     const catLabels = report.categories.map((c) => c.name);
     const expenseData = report.categories.map((c) => c.expenses);
     const budgetData = report.categories.map((c) => c.budget);
@@ -99,6 +100,8 @@ export default function Dashboard() {
       </>
     );
   } else {
+    if (!report.expenses || !Array.isArray(report.expenses.items))
+      return <p className='p-4'>Cargando...</p>;
     const expenses = report.expenses.items;
     const left = Math.max(report.budget - report.expenses.total, 0);
     const pieData = {

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -1,7 +1,16 @@
 import React, { useState } from 'react';
 import { Bar, Pie } from 'react-chartjs-2';
-import { Chart as ChartJS, ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+} from 'chart.js';
 import useReport from '../hooks/useReport.js';
+import useCategories from '../hooks/useCategories.js';
 
 ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
@@ -12,58 +21,167 @@ const ranges = [
 ];
 
 export default function Dashboard() {
+  const categories = useCategories();
   const [range, setRange] = useState('month');
-  const report = useReport(range);
+  const [category, setCategory] = useState('all');
+  const report = useReport(range, category);
 
   if (!report) return <p className='p-4'>Cargando...</p>;
 
-  const categoryLabels = report.categories.map((c) => c.name);
-  const expenseData = report.categories.map((c) => c.expenses);
-  const budgetData = report.categories.map((c) => c.budget);
+  const categoryOptions = [
+    { value: 'all', label: 'Todas' },
+    ...categories.map((c) => ({ value: String(c.id), label: c.name })),
+  ];
 
-  const barData = {
-    labels: categoryLabels,
-    datasets: [
-      {
-        label: 'Gastos',
-        backgroundColor: 'rgba(255,99,132,0.5)',
-        data: expenseData,
-      },
-      {
-        label: 'Presupuesto',
-        backgroundColor: 'rgba(54,162,235,0.5)',
-        data: budgetData,
-      },
-    ],
-  };
+  const makeColors = (n) =>
+    Array.from({ length: n }, (_, i) => `hsl(${(i * 60) % 360},70%,60%)`);
 
-  const pieData = {
-    labels: ['Gastos', 'Presupuesto restante'],
-    datasets: [
-      {
-        data: [report.totalExpenses, Math.max(report.totalBudget - report.totalExpenses, 0)],
-        backgroundColor: ['#ff6384', '#36a2eb'],
+  let content;
+  if (category === 'all') {
+    const catLabels = report.categories.map((c) => c.name);
+    const expenseData = report.categories.map((c) => c.expenses);
+    const budgetData = report.categories.map((c) => c.budget);
+
+    const barData = {
+      labels: catLabels,
+      datasets: [
+        {
+          label: 'Gastos',
+          backgroundColor: 'rgba(255,99,132,0.5)',
+          data: expenseData,
+        },
+        {
+          label: 'Presupuesto',
+          backgroundColor: 'rgba(54,162,235,0.5)',
+          data: budgetData,
+        },
+      ],
+    };
+
+    const expenses = report.expenses;
+    const totalLeft = Math.max(report.totalBudget - report.totalExpenses, 0);
+    const pieData = {
+      labels: expenses.map((_, i) => `Gasto ${i + 1}`).concat(['Restante']),
+      datasets: [
+        {
+          data: expenses.map((e) => e.amount).concat([totalLeft]),
+          backgroundColor: makeColors(expenses.length + 1),
+        },
+      ],
+    };
+
+    const pieOptions = {
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: (ctx) => {
+              if (ctx.dataIndex === expenses.length)
+                return `Restante: $${totalLeft.toFixed(2)}`;
+              const e = expenses[ctx.dataIndex];
+              const date = new Date(e.date).toLocaleDateString();
+              return `${date}: $${e.amount.toFixed(2)}${e.description ? ' - ' + e.description : ''}`;
+            },
+          },
+        },
       },
-    ],
-  };
+    };
+
+    content = (
+      <>
+        <div className='mb-8'>
+          <h3 className='text-lg mb-2'>General</h3>
+          <Pie data={pieData} options={pieOptions} />
+        </div>
+        <div>
+          <h3 className='text-lg mb-2'>Por categoría</h3>
+          <Bar data={barData} />
+        </div>
+      </>
+    );
+  } else {
+    const expenses = report.expenses.items;
+    const left = Math.max(report.budget - report.expenses.total, 0);
+    const pieData = {
+      labels: expenses.map((_, i) => `Gasto ${i + 1}`).concat(['Restante']),
+      datasets: [
+        {
+          data: expenses.map((e) => e.amount).concat([left]),
+          backgroundColor: makeColors(expenses.length + 1),
+        },
+      ],
+    };
+    const pieOptions = {
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: (ctx) => {
+              if (ctx.dataIndex === expenses.length)
+                return `Restante: $${left.toFixed(2)}`;
+              const e = expenses[ctx.dataIndex];
+              const date = new Date(e.date).toLocaleDateString();
+              return `${date}: $${e.amount.toFixed(2)}${e.description ? ' - ' + e.description : ''}`;
+            },
+          },
+        },
+      },
+    };
+
+    const barData = {
+      labels: ['Presupuesto'],
+      datasets: [
+        {
+          label: 'Gastos',
+          backgroundColor: 'rgba(255,99,132,0.5)',
+          data: [report.expenses.total],
+        },
+        {
+          label: 'Presupuesto',
+          backgroundColor: 'rgba(54,162,235,0.5)',
+          data: [report.budget],
+        },
+      ],
+    };
+
+    content = (
+      <>
+        <div className='mb-8'>
+          <h3 className='text-lg mb-2'>{report.name}</h3>
+          <Bar data={barData} />
+        </div>
+        <div>
+          <Pie data={pieData} options={pieOptions} />
+        </div>
+      </>
+    );
+  }
 
   return (
     <div className='p-4'>
-      <div className='mb-4'>
-        <select value={range} onChange={(e) => setRange(e.target.value)} className='text-black p-1 rounded'>
+      <div className='flex gap-4 mb-4'>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className='text-black p-1 rounded'
+        >
+          {categoryOptions.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={range}
+          onChange={(e) => setRange(e.target.value)}
+          className='text-black p-1 rounded'
+        >
           {ranges.map((r) => (
-            <option key={r.value} value={r.value}>{r.label}</option>
+            <option key={r.value} value={r.value}>
+              {r.label}
+            </option>
           ))}
         </select>
       </div>
-      <div className='mb-8'>
-        <h3 className='text-lg mb-2'>General</h3>
-        <Pie data={pieData} />
-      </div>
-      <div>
-        <h3 className='text-lg mb-2'>Por categoría</h3>
-        <Bar data={barData} />
-      </div>
+      {content}
     </div>
   );
 }

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Bar, Pie } from 'react-chartjs-2';
+import { Chart as ChartJS, ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+import useReport from '../hooks/useReport.js';
+
+ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const ranges = [
+  { value: 'month', label: 'Este mes' },
+  { value: 'week', label: 'Última semana' },
+  { value: 'year', label: 'Último año' },
+];
+
+export default function Dashboard() {
+  const [range, setRange] = useState('month');
+  const report = useReport(range);
+
+  if (!report) return <p className='p-4'>Cargando...</p>;
+
+  const categoryLabels = report.categories.map((c) => c.name);
+  const expenseData = report.categories.map((c) => c.expenses);
+  const budgetData = report.categories.map((c) => c.budget);
+
+  const barData = {
+    labels: categoryLabels,
+    datasets: [
+      {
+        label: 'Gastos',
+        backgroundColor: 'rgba(255,99,132,0.5)',
+        data: expenseData,
+      },
+      {
+        label: 'Presupuesto',
+        backgroundColor: 'rgba(54,162,235,0.5)',
+        data: budgetData,
+      },
+    ],
+  };
+
+  const pieData = {
+    labels: ['Gastos', 'Presupuesto restante'],
+    datasets: [
+      {
+        data: [report.totalExpenses, Math.max(report.totalBudget - report.totalExpenses, 0)],
+        backgroundColor: ['#ff6384', '#36a2eb'],
+      },
+    ],
+  };
+
+  return (
+    <div className='p-4'>
+      <div className='mb-4'>
+        <select value={range} onChange={(e) => setRange(e.target.value)} className='text-black p-1 rounded'>
+          {ranges.map((r) => (
+            <option key={r.value} value={r.value}>{r.label}</option>
+          ))}
+        </select>
+      </div>
+      <div className='mb-8'>
+        <h3 className='text-lg mb-2'>General</h3>
+        <Pie data={pieData} />
+      </div>
+      <div>
+        <h3 className='text-lg mb-2'>Por categoría</h3>
+        <Bar data={barData} />
+      </div>
+    </div>
+  );
+}

--- a/front/src/hooks/useReport.js
+++ b/front/src/hooks/useReport.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { fetchReport } from '../services/api.js';
+
+export default function useReport(range) {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchReport(range)
+      .then((d) => {
+        if (active) setData(d);
+      })
+      .catch((err) => console.error(err));
+    return () => {
+      active = false;
+    };
+  }, [range]);
+
+  return data;
+}

--- a/front/src/hooks/useReport.js
+++ b/front/src/hooks/useReport.js
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 import { fetchReport } from '../services/api.js';
 
-export default function useReport(range) {
+export default function useReport(range, category) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
     let active = true;
-    fetchReport(range)
+    setData(null); 
+    fetchReport(range, category)
       .then((d) => {
         if (active) setData(d);
       })
@@ -14,7 +15,7 @@ export default function useReport(range) {
     return () => {
       active = false;
     };
-  }, [range]);
+  }, [range, category]);
 
   return data;
 }

--- a/front/src/hooks/useSummaryTable.js
+++ b/front/src/hooks/useSummaryTable.js
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
-import { fetchReport } from '../services/api.js';
+import { fetchSummaryTable } from '../services/api.js';
 
-export default function useReport(range, category) {
+export default function useSummaryTable(enabled) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
+    if (!enabled) return;
     let active = true;
-    setData(null); // reset while fetching new data
-    fetchReport(range, category)
+    fetchSummaryTable()
       .then((d) => {
         if (active) setData(d);
       })
@@ -15,7 +15,7 @@ export default function useReport(range, category) {
     return () => {
       active = false;
     };
-  }, [range, category]);
+  }, [enabled]);
 
   return data;
 }

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -4,14 +4,13 @@ import ReviewerForm from '../components/ReviewerForm.jsx';
 import CategoryForm from '../components/CategoryForm.jsx';
 import ExpenseForm from '../components/ExpenseForm.jsx';
 import Navbar from '../components/Navbar.jsx';
+import Dashboard from '../components/Dashboard.jsx';
 
 export default function HomePage() {
   const { user, logout, changeCurrency } = useAuth();
   const [view, setView] = useState('home');
 
-  let content = (
-    <div className='p-4'>Bienvenido, {user.username}</div>
-  );
+  let content = <Dashboard />;
   if (view === 'reviewer') {
     content = (
       <div className='p-4'>

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -87,3 +87,9 @@ export async function fetchReport(range = 'month', category = 'all') {
   if (!res.ok) throw new Error('Failed to fetch report');
   return res.json();
 }
+
+export async function fetchSummaryTable() {
+  const res = await fetch(`${REPORT_URL}/summary-table`);
+  if (!res.ok) throw new Error('Failed to fetch report table');
+  return res.json();
+}

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -78,8 +78,12 @@ export async function createExpense(data) {
   return res.json();
 }
 
-export async function fetchReport(range = 'month') {
-  const res = await fetch(`${REPORT_URL}/summary?range=${range}`);
+export async function fetchReport(range = 'month', category = 'all') {
+  const url =
+    category === 'all'
+      ? `${REPORT_URL}/summary?range=${range}`
+      : `${REPORT_URL}/category/${category}?range=${range}`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to fetch report');
   return res.json();
 }

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -4,6 +4,7 @@ const CATEGORY_URL = '/api/categorias';
 const USER_URL = '/api/users';
 const DIVISA_URL = '/api/divisas';
 const EXPENSE_URL = '/api/gastos';
+const REPORT_URL = '/api/reports';
 
 export async function registerUser(data) {
   const res = await fetch(`${API_URL}/register`, {
@@ -74,5 +75,11 @@ export async function createExpense(data) {
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error('Failed to create expense');
+  return res.json();
+}
+
+export async function fetchReport(range = 'month') {
+  const res = await fetch(`${REPORT_URL}/summary?range=${range}`);
+  if (!res.ok) throw new Error('Failed to fetch report');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add reporting service and route in backend
- display dashboard instead of welcome screen
- fetch reports and render charts
- install chart.js and react-chartjs-2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68635c7759c08325953038f6cef3b3f7