### PR TITLE
Add dashboard view with charts

### DIFF
--- a/back/controllers/dashboard.controller.js
+++ b/back/controllers/dashboard.controller.js
@@ -1,0 +1,25 @@
+import { getCategoryStats } from '../services/dashboardService.js';
+
+export async function dashboardData(req, res) {
+  try {
+    let { start, end } = req.query;
+    const today = new Date();
+    if (!start) {
+      start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+    } else {
+      start = new Date(start);
+    }
+    if (!end) {
+      end = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 0));
+    } else {
+      end = new Date(end);
+    }
+    const categories = await getCategoryStats(start, end);
+    const totalBudget = categories.reduce((a, c) => a + c.budget, 0);
+    const totalExpenses = categories.reduce((a, c) => a + c.expenses, 0);
+    res.json({ categories, totalBudget, totalExpenses });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch dashboard data' });
+  }
+}

--- a/back/index.js
+++ b/back/index.js
@@ -7,6 +7,7 @@ import categoriaRoutes from './routes/categorias.routes.js';
 import usuarioRoutes from './routes/usuarios.routes.js';
 import divisaRoutes from './routes/divisas.routes.js';
 import gastoRoutes from './routes/gastos.routes.js';
+import dashboardRoutes from './routes/dashboard.routes.js';
 import { startRecurringExpenseJob } from './cron/recurringExpenses.js';
 import { startDivisaUpdateJob } from './cron/updateDivisas.js';
 
@@ -21,6 +22,7 @@ app.use('/api/categorias', categoriaRoutes);
 app.use('/api/users', usuarioRoutes);
 app.use('/api/divisas', divisaRoutes);
 app.use('/api/gastos', gastoRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 async function start() {
   await testConnection();

--- a/back/routes/dashboard.routes.js
+++ b/back/routes/dashboard.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { dashboardData } from '../controllers/dashboard.controller.js';
+
+const router = Router();
+
+router.get('/', dashboardData);
+
+export default router;

--- a/back/services/dashboardService.js
+++ b/back/services/dashboardService.js
@@ -1,0 +1,63 @@
+import { Categoria } from '../models/categoria.model.js';
+import { Presupuesto } from '../models/presupuesto.model.js';
+import { Gasto } from '../models/gasto.model.js';
+import { Op, fn, col, literal } from 'sequelize';
+
+function monthRange(start, end) {
+  const months = [];
+  const cur = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1));
+  const last = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+  while (cur <= last) {
+    months.push({ month: cur.getUTCMonth() + 1, year: cur.getUTCFullYear() });
+    cur.setUTCMonth(cur.getUTCMonth() + 1);
+  }
+  return months;
+}
+
+export async function getCategoryStats(startDate, endDate) {
+  const categories = await Categoria.findAll({ attributes: ['id', 'name'], raw: true });
+  const categoryIds = categories.map(c => c.id);
+
+  const expenses = await Gasto.findAll({
+    where: { date: { [Op.between]: [startDate, endDate] }, category_id: { [Op.in]: categoryIds } },
+    attributes: ['category_id', [fn('SUM', col('amount')), 'total']],
+    group: ['category_id'],
+    raw: true,
+  });
+
+  const expenseMap = {};
+  for (const e of expenses) {
+    expenseMap[e.category_id] = parseFloat(e.total);
+  }
+
+  const presupuestos = await Presupuesto.findAll({ where: { category_id: { [Op.in]: categoryIds } }, raw: true });
+
+  const months = monthRange(startDate, endDate);
+
+  const budgetMap = {};
+  for (const c of categories) budgetMap[c.id] = 0;
+
+  for (const p of presupuestos) {
+    for (const m of months) {
+      const monthDate = new Date(Date.UTC(m.year, m.month - 1, 1));
+      const startRec = new Date(Date.UTC(p.period_year, p.period_month - 1, 1));
+      if (p.recurring) {
+        const endRec = new Date(p.recurrence_end_date);
+        if (startRec <= monthDate && endRec >= monthDate) {
+          budgetMap[p.category_id] += parseFloat(p.amount);
+        }
+      } else {
+        if (p.period_year === m.year && p.period_month === m.month) {
+          budgetMap[p.category_id] += parseFloat(p.amount);
+        }
+      }
+    }
+  }
+
+  return categories.map(c => ({
+    id: c.id,
+    name: c.name,
+    budget: budgetMap[c.id] || 0,
+    expenses: expenseMap[c.id] || 0,
+  }));
+}

--- a/front/package.json
+++ b/front/package.json
@@ -16,7 +16,9 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import useDashboard from '../hooks/useDashboard.js';
+import { Pie, Bar } from 'react-chartjs-2';
+import { Chart, ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+
+Chart.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const ranges = {
+  month: { label: 'Este mes', start: () => new Date(new Date().getFullYear(), new Date().getMonth(), 1), end: () => new Date() },
+  week: { label: 'Última semana', start: () => { const d = new Date(); d.setDate(d.getDate()-7); return d; }, end: () => new Date() },
+  year: { label: 'Último año', start: () => { const d = new Date(); d.setFullYear(d.getFullYear()-1); return d; }, end: () => new Date() },
+};
+
+export default function Dashboard() {
+  const [rangeKey, setRangeKey] = useState('month');
+  const range = ranges[rangeKey];
+  const { data, loading, error } = useDashboard({
+    start: range.start().toISOString().slice(0,10),
+    end: range.end().toISOString().slice(0,10)
+  });
+
+  if (loading) return <p>Cargando...</p>;
+  if (error) return <p className='text-red-500'>{error}</p>;
+  if (!data) return null;
+
+  const categoryLabels = data.categories.map(c => c.name);
+  const budgetData = data.categories.map(c => c.budget);
+  const expenseData = data.categories.map(c => c.expenses);
+
+  const pieData = {
+    labels: categoryLabels,
+    datasets: [{ data: expenseData, backgroundColor: ['#4ade80', '#60a5fa', '#f472b6', '#facc15', '#a78bfa'] }],
+  };
+
+  const barData = {
+    labels: categoryLabels,
+    datasets: [
+      { label: 'Presupuesto', data: budgetData, backgroundColor: '#60a5fa' },
+      { label: 'Gastos', data: expenseData, backgroundColor: '#f87171' },
+    ],
+  };
+
+  const totalData = {
+    labels: ['Presupuesto', 'Gastos'],
+    datasets: [{ data: [data.totalBudget, data.totalExpenses], backgroundColor: ['#60a5fa', '#f87171'] }],
+  };
+
+  return (
+    <div className='p-4'>
+      <div className='mb-4'>
+        {Object.entries(ranges).map(([key, r]) => (
+          <button key={key} className={`mr-2 ${key===rangeKey?'font-bold':''}`} onClick={() => setRangeKey(key)}>
+            {r.label}
+          </button>
+        ))}
+      </div>
+      <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+        <div>
+          <h3 className='text-lg mb-2'>Gastos por categoría</h3>
+          <Pie data={pieData} />
+        </div>
+        <div>
+          <h3 className='text-lg mb-2'>Presupuesto vs Gastos</h3>
+          <Bar data={barData} />
+        </div>
+      </div>
+      <div className='mt-6'>
+        <h3 className='text-lg mb-2'>Totales</h3>
+        <Pie data={totalData} />
+      </div>
+    </div>
+  );
+}
+
+Dashboard.propTypes = {
+  rangeKey: PropTypes.string,
+};

--- a/front/src/hooks/useDashboard.js
+++ b/front/src/hooks/useDashboard.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { fetchDashboard } from '../services/api.js';
+
+export default function useDashboard(range) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const { start, end } = range;
+    setLoading(true);
+    fetchDashboard(start, end)
+      .then((res) => {
+        setData(res);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError('Failed to load dashboard');
+      })
+      .finally(() => setLoading(false));
+  }, [range]);
+
+  return { data, loading, error };
+}

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -4,13 +4,14 @@ import ReviewerForm from '../components/ReviewerForm.jsx';
 import CategoryForm from '../components/CategoryForm.jsx';
 import ExpenseForm from '../components/ExpenseForm.jsx';
 import Navbar from '../components/Navbar.jsx';
+import Dashboard from '../components/Dashboard.jsx';
 
 export default function HomePage() {
   const { user, logout, changeCurrency } = useAuth();
   const [view, setView] = useState('home');
 
   let content = (
-    <div className='p-4'>Bienvenido, {user.username}</div>
+    <Dashboard />
   );
   if (view === 'reviewer') {
     content = (

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -4,6 +4,7 @@ const CATEGORY_URL = '/api/categorias';
 const USER_URL = '/api/users';
 const DIVISA_URL = '/api/divisas';
 const EXPENSE_URL = '/api/gastos';
+const DASHBOARD_URL = '/api/dashboard';
 
 export async function registerUser(data) {
   const res = await fetch(`${API_URL}/register`, {
@@ -74,5 +75,14 @@ export async function createExpense(data) {
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error('Failed to create expense');
+  return res.json();
+}
+
+export async function fetchDashboard(start, end) {
+  const params = new URLSearchParams();
+  if (start) params.append('start', start);
+  if (end) params.append('end', end);
+  const res = await fetch(`${DASHBOARD_URL}?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch dashboard');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- create dashboard API endpoint to aggregate budget and expense totals
- expose dashboard route on the backend
- add React hook and component to display dashboard charts
- update HomePage to show new dashboard
- include chart.js and react-chartjs-2 dependencies

## Testing
- `npm test`
- `npm run lint --prefix front`

------
https://chatgpt.com/codex/tasks/task_e_68635c7759c08325953038f6cef3b3f7