### PR TITLE
Fix category payload mismatch

### DIFF
--- a/front/src/components/CategoryForm.jsx
+++ b/front/src/components/CategoryForm.jsx
@@ -85,11 +85,11 @@ export default function CategoryForm() {
           name,
           description,
           recurring: false,
+          currency_code: currency,
           budgets: budgets.map((b) => ({
             month: Number(b.month),
             year: Number(b.year),
             amount: parseFloat(b.amount),
-            currency_code: currency,
           })),
         };
       }


### PR DESCRIPTION
## Summary
- include `currency_code` in the non-recurring payload sent from `CategoryForm`

This ensures the backend receives the expected `currency_code` when creating a category without a recurring budget.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68636bd6135c832596d015734300710d