### PR TITLE
Add dashboard for expenses overview

### DIFF
--- a/back/controllers/dashboard.controller.js
+++ b/back/controllers/dashboard.controller.js
@@ -1,0 +1,11 @@
+import { getDashboardData } from '../services/dashboardService.js';
+
+export async function getDashboard(req, res) {
+  try {
+    const period = req.query.period || 'this_month';
+    const data = await getDashboardData(period);
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/back/index.js
+++ b/back/index.js
@@ -7,6 +7,7 @@ import categoriaRoutes from './routes/categorias.routes.js';
 import usuarioRoutes from './routes/usuarios.routes.js';
 import divisaRoutes from './routes/divisas.routes.js';
 import gastoRoutes from './routes/gastos.routes.js';
+import dashboardRoutes from './routes/dashboard.routes.js';
 import { startRecurringExpenseJob } from './cron/recurringExpenses.js';
 import { startDivisaUpdateJob } from './cron/updateDivisas.js';
 
@@ -21,6 +22,7 @@ app.use('/api/categorias', categoriaRoutes);
 app.use('/api/users', usuarioRoutes);
 app.use('/api/divisas', divisaRoutes);
 app.use('/api/gastos', gastoRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 async function start() {
   await testConnection();

--- a/back/routes/dashboard.routes.js
+++ b/back/routes/dashboard.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getDashboard } from '../controllers/dashboard.controller.js';
+
+const router = Router();
+
+router.get('/', getDashboard);
+
+export default router;

--- a/back/services/dashboardService.js
+++ b/back/services/dashboardService.js
@@ -1,0 +1,62 @@
+import { sequelize } from '../config/index.js';
+import { QueryTypes } from 'sequelize';
+
+function getPeriodDates(period) {
+  const now = new Date();
+  let start, end;
+  switch (period) {
+    case 'last_week':
+      end = new Date(now);
+      start = new Date(now);
+      start.setDate(start.getDate() - 7);
+      break;
+    case 'last_month':
+      start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      end = new Date(now.getFullYear(), now.getMonth(), 0);
+      break;
+    case 'last_year':
+      start = new Date(now.getFullYear() - 1, 0, 1);
+      end = new Date(now.getFullYear() - 1, 11, 31);
+      break;
+    default:
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
+      end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+      break;
+  }
+  start.setHours(0, 0, 0, 0);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+export async function getDashboardData(period = 'this_month') {
+  const { start, end } = getPeriodDates(period);
+  const query = `
+    SELECT c.id, c.name,
+      COALESCE(SUM(p.amount), 0) AS budget,
+      COALESCE(SUM(g.amount), 0) AS expenses
+    FROM categorias c
+    LEFT JOIN presupuestos p ON p.category_id = c.id
+      AND STR_TO_DATE(CONCAT(p.period_year,'-',LPAD(p.period_month,2,'0'),'-01'), '%Y-%m-%d')
+        BETWEEN :start AND :end
+    LEFT JOIN gastos g ON g.category_id = c.id
+      AND g.date BETWEEN :start AND :end
+    GROUP BY c.id, c.name
+    ORDER BY c.name
+  `;
+  const rows = await sequelize.query(query, {
+    replacements: { start, end },
+    type: QueryTypes.SELECT,
+  });
+  let totalBudget = 0;
+  let totalExpenses = 0;
+  const categories = rows.map((r) => {
+    const b = Number(r.budget);
+    const e = Number(r.expenses);
+    totalBudget += b;
+    totalExpenses += e;
+    return { id: r.id, name: r.name, budget: b, expenses: e };
+  });
+  return { categories, totalBudget, totalExpenses };
+}
+
+export { getPeriodDates };

--- a/front/package.json
+++ b/front/package.json
@@ -12,9 +12,11 @@
   },
   "dependencies": {
     "@material/web": "^1.5.1",
+    "chart.js": "^4.5.0",
     "lit": "^3.3.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0"
   },

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import CustomSelect from './CustomSelect.jsx';
+import { fetchDashboard } from '../services/api.js';
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const options = [
+  { value: 'this_month', label: 'Este mes' },
+  { value: 'last_week', label: 'Última semana' },
+  { value: 'last_month', label: 'Último mes' },
+  { value: 'last_year', label: 'Último año' },
+];
+
+export default function Dashboard() {
+  const [period, setPeriod] = useState('this_month');
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetchDashboard(period)
+      .then(setData)
+      .catch((err) => console.error(err));
+  }, [period]);
+
+  if (!data) {
+    return <p className='p-4'>Cargando...</p>;
+  }
+
+  const chartData = {
+    labels: data.categories.map((c) => c.name),
+    datasets: [
+      {
+        label: 'Presupuesto',
+        data: data.categories.map((c) => c.budget),
+        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+      },
+      {
+        label: 'Gastos',
+        data: data.categories.map((c) => c.expenses),
+        backgroundColor: 'rgba(255, 99, 132, 0.5)',
+      },
+    ],
+  };
+
+  const totalData = {
+    labels: ['Total'],
+    datasets: [
+      {
+        label: 'Presupuesto',
+        data: [data.totalBudget],
+        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+      },
+      {
+        label: 'Gastos',
+        data: [data.totalExpenses],
+        backgroundColor: 'rgba(255, 99, 132, 0.5)',
+      },
+    ],
+  };
+
+  return (
+    <div className='p-4'>
+      <div className='mb-4'>
+        <CustomSelect
+          name='period'
+          id='period'
+          value={period}
+          onChange={(e) => setPeriod(e.target.value)}
+          options={options}
+        >
+          Periodo
+        </CustomSelect>
+      </div>
+      <Bar data={chartData} />
+      <div className='mt-8'>
+        <h2 className='text-xl mb-2'>General</h2>
+        <Bar data={totalData} />
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/HomePage.jsx
+++ b/front/src/pages/HomePage.jsx
@@ -4,14 +4,13 @@ import ReviewerForm from '../components/ReviewerForm.jsx';
 import CategoryForm from '../components/CategoryForm.jsx';
 import ExpenseForm from '../components/ExpenseForm.jsx';
 import Navbar from '../components/Navbar.jsx';
+import Dashboard from '../components/Dashboard.jsx';
 
 export default function HomePage() {
   const { user, logout, changeCurrency } = useAuth();
   const [view, setView] = useState('home');
 
-  let content = (
-    <div className='p-4'>Bienvenido, {user.username}</div>
-  );
+  let content = <Dashboard />;
   if (view === 'reviewer') {
     content = (
       <div className='p-4'>

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -4,6 +4,7 @@ const CATEGORY_URL = '/api/categorias';
 const USER_URL = '/api/users';
 const DIVISA_URL = '/api/divisas';
 const EXPENSE_URL = '/api/gastos';
+const DASHBOARD_URL = '/api/dashboard';
 
 export async function registerUser(data) {
   const res = await fetch(`${API_URL}/register`, {
@@ -74,5 +75,11 @@ export async function createExpense(data) {
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error('Failed to create expense');
+  return res.json();
+}
+
+export async function fetchDashboard(period = 'this_month') {
+  const res = await fetch(`${DASHBOARD_URL}?period=${period}`);
+  if (!res.ok) throw new Error('Failed to fetch dashboard');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add dashboard service on backend
- expose `/api/dashboard` endpoint
- show new dashboard on the Inicio tab
- fetch dashboard data from React and display charts
- include Chart.js dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68635c7759c08325953038f6cef3b3f7