### PR TITLE
Add dashboard table crosshair highlight

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+- [ ] Si se pasa el presupuesto por dos meses seguidos, agregar una alerta cuando se esté registrando una compra con ese rubro.
+- [ ] Módulo de notificaciones
+- [ ] Módulo de revisor: agregar sección donde se agregue un rol (si puede o no registrar gastos, agregar categorías)
+- [ ] Despliegue

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -259,7 +259,7 @@ export default function Dashboard() {
           >
             <thead>
               <tr>
-                <th className='border px-2 whitespace-nowrap sticky left-0 bg-background z-10'>Rubros</th>
+                <th className='border px-2 whitespace-nowrap sticky left-0 bg-background z-10 sticky-col'>Rubros</th>
                 <th className='border px-2 whitespace-nowrap' colSpan={3}>Antes</th>
                 {table.months.map((m) => (
                   <th
@@ -274,7 +274,7 @@ export default function Dashboard() {
               </tr>
               <tr>
                 <th
-                  className={`${cellClass(0)} sticky left-0 bg-background`}
+                  className={`${cellClass(0)} sticky left-0 bg-background sticky-col`}
                   onMouseEnter={() => setHoverCol(0)}
                 ></th>
                 <th
@@ -335,7 +335,7 @@ export default function Dashboard() {
               {table.categories.map((cat) => (
                 <tr key={cat.id}>
                   <td
-                    className={`${cellClass(0)} text-left sticky left-0 bg-background`}
+                    className={`${cellClass(0)} text-left sticky left-0 bg-background sticky-col`}
                     onMouseEnter={() => setHoverCol(0)}
                   >
                     {cat.name}
@@ -397,7 +397,7 @@ export default function Dashboard() {
               {totals && (
                 <tr className='font-semibold'>
                   <td
-                    className={`${cellClass(0)} sticky left-0 bg-background`}
+                    className={`${cellClass(0)} sticky left-0 bg-background sticky-col`}
                     onMouseEnter={() => setHoverCol(0)}
                   >
                     Mensual
@@ -459,7 +459,7 @@ export default function Dashboard() {
               {totals && (
                 <tr className='font-semibold'>
                   <td
-                    className={`${cellClass(0)} sticky left-0 bg-background`}
+                    className={`${cellClass(0)} sticky left-0 bg-background sticky-col`}
                     onMouseEnter={() => setHoverCol(0)}
                   >
                     Acumulado

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -27,6 +27,7 @@ export default function Dashboard() {
   const [category, setCategory] = useState('all');
   const report = useReport(range, category);
   const table = useSummaryTable(category === 'all');
+  const [hoverCol, setHoverCol] = useState(null);
 
   if (!report) return <p className='p-4'>Cargando...</p>;
 
@@ -40,6 +41,9 @@ export default function Dashboard() {
 
   const monthName = (m) =>
     new Date(2000, m - 1, 1).toLocaleString('es', { month: 'short' }).toUpperCase();
+
+  const cellClass = (idx) =>
+    `border px-2 whitespace-nowrap ${hoverCol === idx ? 'col-hover' : ''}`;
 
   const totals = table
     ? (() => {
@@ -70,9 +74,10 @@ export default function Dashboard() {
           (s, c) => s + c.totalReal,
           0
         );
-        return { antesBudget, antesReal, monthTotals, totalBudget, totalReal };
-      })()
+      return { antesBudget, antesReal, monthTotals, totalBudget, totalReal };
+    })()
     : null;
+  const monthCount = table ? table.months.length : 0;
 
   const mensualDiffs = totals
     ? [
@@ -248,7 +253,10 @@ export default function Dashboard() {
       {content}
       {category === 'all' && table && (
         <div className='overflow-x-auto mt-8'>
-          <table className='min-w-max text-sm border-collapse whitespace-nowrap'>
+          <table
+            className='min-w-max text-sm border-collapse whitespace-nowrap crosshair-table'
+            onMouseLeave={() => setHoverCol(null)}
+          >
             <thead>
               <tr>
                 <th className='border px-2 whitespace-nowrap sticky left-0 bg-background z-10'>Rubros</th>
@@ -265,91 +273,237 @@ export default function Dashboard() {
                 <th className='border px-2 whitespace-nowrap' colSpan='2'>Total por rubro</th>
               </tr>
               <tr>
-                <th className='sticky left-0 bg-background'></th>
-                <th className='border px-2 whitespace-nowrap'>Presupuesto</th>
-                <th className='border px-2 whitespace-nowrap'>Real</th>
-                <th className='border px-2 whitespace-nowrap'>Dif</th>
-                {table.months.map((m) => (
+                <th
+                  className={`${cellClass(0)} sticky left-0 bg-background`}
+                  onMouseEnter={() => setHoverCol(0)}
+                ></th>
+                <th
+                  className={cellClass(1)}
+                  onMouseEnter={() => setHoverCol(1)}
+                >
+                  Presupuesto
+                </th>
+                <th
+                  className={cellClass(2)}
+                  onMouseEnter={() => setHoverCol(2)}
+                >
+                  Real
+                </th>
+                <th
+                  className={cellClass(3)}
+                  onMouseEnter={() => setHoverCol(3)}
+                >
+                  Dif
+                </th>
+                {table.months.map((m, mi) => (
                   <React.Fragment key={`h-${m.year}-${m.month}`}>
-                    <th className='border px-2 whitespace-nowrap'>Presupuesto</th>
-                    <th className='border px-2 whitespace-nowrap'>Real</th>
-                    <th className='border px-2 whitespace-nowrap'>Dif</th>
+                    <th
+                      className={cellClass(4 + mi * 3)}
+                      onMouseEnter={() => setHoverCol(4 + mi * 3)}
+                    >
+                      Presupuesto
+                    </th>
+                    <th
+                      className={cellClass(4 + mi * 3 + 1)}
+                      onMouseEnter={() => setHoverCol(4 + mi * 3 + 1)}
+                    >
+                      Real
+                    </th>
+                    <th
+                      className={cellClass(4 + mi * 3 + 2)}
+                      onMouseEnter={() => setHoverCol(4 + mi * 3 + 2)}
+                    >
+                      Dif
+                    </th>
                   </React.Fragment>
                 ))}
-                <th className='border px-2 whitespace-nowrap'>Presupuesto</th>
-                <th className='border px-2 whitespace-nowrap'>Real</th>
+                <th
+                  className={cellClass(4 + monthCount * 3)}
+                  onMouseEnter={() => setHoverCol(4 + monthCount * 3)}
+                >
+                  Presupuesto
+                </th>
+                <th
+                  className={cellClass(5 + monthCount * 3)}
+                  onMouseEnter={() => setHoverCol(5 + monthCount * 3)}
+                >
+                  Real
+                </th>
               </tr>
             </thead>
             <tbody>
               {table.categories.map((cat) => (
                 <tr key={cat.id}>
-                  <td className='border px-2 text-left whitespace-nowrap sticky left-0 bg-background'>{cat.name}</td>
-                  <td className='border px-2 whitespace-nowrap'>{cat.antesBudget.toFixed(2)}</td>
-                  <td className='border px-2 whitespace-nowrap'>{cat.antesReal.toFixed(2)}</td>
-                  <td className='border px-2 whitespace-nowrap'>
+                  <td
+                    className={`${cellClass(0)} text-left sticky left-0 bg-background`}
+                    onMouseEnter={() => setHoverCol(0)}
+                  >
+                    {cat.name}
+                  </td>
+                  <td
+                    className={cellClass(1)}
+                    onMouseEnter={() => setHoverCol(1)}
+                  >
+                    {cat.antesBudget.toFixed(2)}
+                  </td>
+                  <td
+                    className={cellClass(2)}
+                    onMouseEnter={() => setHoverCol(2)}
+                  >
+                    {cat.antesReal.toFixed(2)}
+                  </td>
+                  <td
+                    className={cellClass(3)}
+                    onMouseEnter={() => setHoverCol(3)}
+                  >
                     {(cat.antesBudget - cat.antesReal).toFixed(2)}
                   </td>
                   {cat.months.map((m, idx) => (
                     <React.Fragment key={idx}>
-                      <td className='border px-2 whitespace-nowrap'>{m.budget.toFixed(2)}</td>
-                      <td className='border px-2 whitespace-nowrap'>{m.real.toFixed(2)}</td>
-                      <td className='border px-2 whitespace-nowrap'>
+                      <td
+                        className={cellClass(4 + idx * 3)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3)}
+                      >
+                        {m.budget.toFixed(2)}
+                      </td>
+                      <td
+                        className={cellClass(4 + idx * 3 + 1)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3 + 1)}
+                      >
+                        {m.real.toFixed(2)}
+                      </td>
+                      <td
+                        className={cellClass(4 + idx * 3 + 2)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3 + 2)}
+                      >
                         {(m.budget - m.real).toFixed(2)}
                       </td>
                     </React.Fragment>
                   ))}
-                  <td className='border px-2 whitespace-nowrap'>{cat.totalBudget.toFixed(2)}</td>
-                  <td className='border px-2 whitespace-nowrap'>{cat.totalReal.toFixed(2)}</td>
+                  <td
+                    className={cellClass(4 + monthCount * 3)}
+                    onMouseEnter={() => setHoverCol(4 + monthCount * 3)}
+                  >
+                    {cat.totalBudget.toFixed(2)}
+                  </td>
+                  <td
+                    className={cellClass(5 + monthCount * 3)}
+                    onMouseEnter={() => setHoverCol(5 + monthCount * 3)}
+                  >
+                    {cat.totalReal.toFixed(2)}
+                  </td>
                 </tr>
               ))}
               {totals && (
                 <tr className='font-semibold'>
-                  <td className='border px-2 whitespace-nowrap sticky left-0 bg-background'>Mensual</td>
-                  <td className='border px-2 whitespace-nowrap'>
+                  <td
+                    className={`${cellClass(0)} sticky left-0 bg-background`}
+                    onMouseEnter={() => setHoverCol(0)}
+                  >
+                    Mensual
+                  </td>
+                  <td
+                    className={cellClass(1)}
+                    onMouseEnter={() => setHoverCol(1)}
+                  >
                     {totals.antesBudget.toFixed(2)}
                   </td>
-                  <td className='border px-2 whitespace-nowrap'>
+                  <td
+                    className={cellClass(2)}
+                    onMouseEnter={() => setHoverCol(2)}
+                  >
                     {totals.antesReal.toFixed(2)}
                   </td>
-                  <td className='border px-2 whitespace-nowrap'>
+                  <td
+                    className={cellClass(3)}
+                    onMouseEnter={() => setHoverCol(3)}
+                  >
                     {mensualDiffs[0].toFixed(2)}
                   </td>
                   {totals.monthTotals.map((m, idx) => (
                     <React.Fragment key={`m-${idx}`}>
-                      <td className='border px-2 whitespace-nowrap'>{m.budget.toFixed(2)}</td>
-                      <td className='border px-2 whitespace-nowrap'>{m.real.toFixed(2)}</td>
-                      <td className='border px-2 whitespace-nowrap'>
+                      <td
+                        className={cellClass(4 + idx * 3)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3)}
+                      >
+                        {m.budget.toFixed(2)}
+                      </td>
+                      <td
+                        className={cellClass(4 + idx * 3 + 1)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3 + 1)}
+                      >
+                        {m.real.toFixed(2)}
+                      </td>
+                      <td
+                        className={cellClass(4 + idx * 3 + 2)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3 + 2)}
+                      >
                         {mensualDiffs[idx + 1].toFixed(2)}
                       </td>
                     </React.Fragment>
                   ))}
-                  <td className='border px-2 whitespace-nowrap'>
+                  <td
+                    className={cellClass(4 + monthCount * 3)}
+                    onMouseEnter={() => setHoverCol(4 + monthCount * 3)}
+                  >
                     {totals.totalBudget.toFixed(2)}
                   </td>
-                  <td className='border px-2 whitespace-nowrap'>
+                  <td
+                    className={cellClass(5 + monthCount * 3)}
+                    onMouseEnter={() => setHoverCol(5 + monthCount * 3)}
+                  >
                     {totals.totalReal.toFixed(2)}
                   </td>
                 </tr>
               )}
               {totals && (
                 <tr className='font-semibold'>
-                  <td className='border px-2 whitespace-nowrap sticky left-0 bg-background'>Acumulado</td>
-                  <td className='border px-2 whitespace-nowrap'></td>
-                  <td className='border px-2 whitespace-nowrap'></td>
-                  <td className='border px-2 whitespace-nowrap'>
+                  <td
+                    className={`${cellClass(0)} sticky left-0 bg-background`}
+                    onMouseEnter={() => setHoverCol(0)}
+                  >
+                    Acumulado
+                  </td>
+                  <td
+                    className={cellClass(1)}
+                    onMouseEnter={() => setHoverCol(1)}
+                  ></td>
+                  <td
+                    className={cellClass(2)}
+                    onMouseEnter={() => setHoverCol(2)}
+                  ></td>
+                  <td
+                    className={cellClass(3)}
+                    onMouseEnter={() => setHoverCol(3)}
+                  >
                     {acumulados[0].toFixed(2)}
                   </td>
                   {totals.monthTotals.map((_, idx) => (
                     <React.Fragment key={`a-${idx}`}>
-                      <td className='border px-2 whitespace-nowrap'></td>
-                      <td className='border px-2 whitespace-nowrap'></td>
-                      <td className='border px-2 whitespace-nowrap'>
+                      <td
+                        className={cellClass(4 + idx * 3)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3)}
+                      ></td>
+                      <td
+                        className={cellClass(4 + idx * 3 + 1)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3 + 1)}
+                      ></td>
+                      <td
+                        className={cellClass(4 + idx * 3 + 2)}
+                        onMouseEnter={() => setHoverCol(4 + idx * 3 + 2)}
+                      >
                         {acumulados[idx + 1].toFixed(2)}
                       </td>
                     </React.Fragment>
                   ))}
-                  <td className='border px-2 whitespace-nowrap'></td>
-                  <td className='border px-2 whitespace-nowrap'></td>
+                  <td
+                    className={cellClass(4 + monthCount * 3)}
+                    onMouseEnter={() => setHoverCol(4 + monthCount * 3)}
+                  ></td>
+                  <td
+                    className={cellClass(5 + monthCount * 3)}
+                    onMouseEnter={() => setHoverCol(5 + monthCount * 3)}
+                  ></td>
                 </tr>
               )}
             </tbody>

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -68,3 +68,11 @@ input[type="password"],
 textarea {
   color: var(--md-sys-color-on-surface);
 }
+
+.crosshair-table tbody tr:hover > * {
+  background-color: rgba(144, 202, 249, 0.2);
+}
+
+.crosshair-table .col-hover {
+  background-color: rgba(144, 202, 249, 0.2);
+}

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -69,7 +69,15 @@ textarea {
   color: var(--md-sys-color-on-surface);
 }
 
-.crosshair-table tbody tr:hover > * {
+.crosshair-table td.sticky-col,
+.crosshair-table th.sticky-col {
+  position: sticky;
+  left: 0;
+  background-color: var(--md-sys-color-background);
+  z-index: 1;
+}
+
+.crosshair-table tbody tr:hover > *:not(.sticky-col) {
   background-color: rgba(144, 202, 249, 0.2);
 }
 


### PR DESCRIPTION
## Summary
- add column/row crosshair hover styles
- implement hover logic in Dashboard table

## Testing
- `npm run lint --prefix front`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686abe1051b8832586bbd19dd77cf22b