### PR TITLE
Add month selection range

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,4 +13,4 @@
 - [x] Agregar feature: pago dividido entre dos
 - [ ] Página HTTPS
 - [ ] Agregar vista de calendario en fecha de registro gasto
-- [ ] Agregar vista de "Seleccionar mes"
+- [x] Agregar vista de "Seleccionar mes"

--- a/back/services/reportService.js
+++ b/back/services/reportService.js
@@ -23,27 +23,33 @@ export async function getSummary(range = 'month', currency = 'MXN') {
   let start;
   let end = new Date();
 
-  switch (range) {
-    case 'week': {
-      start = new Date(now);
-      const day = start.getDay();
-      const diffToMonday = (day + 6) % 7;
-      start.setDate(start.getDate() - diffToMonday);
-      end = new Date(start);
-      end.setDate(start.getDate() + 6);
-      break;
+  if (/^\d{4}-\d{2}$/.test(range)) {
+    const [y, m] = range.split('-').map(Number);
+    start = new Date(y, m - 1, 1);
+    end = new Date(y, m, 0);
+  } else {
+    switch (range) {
+      case 'week': {
+        start = new Date(now);
+        const day = start.getDay();
+        const diffToMonday = (day + 6) % 7;
+        start.setDate(start.getDate() - diffToMonday);
+        end = new Date(start);
+        end.setDate(start.getDate() + 6);
+        break;
+      }
+      case 'all':
+        start = new Date(0);
+        end = new Date();
+        break;
+      case 'year':
+        start = new Date(now.getFullYear() - 1, now.getMonth() + 1, 1);
+        break;
+      case 'month':
+      default:
+        start = new Date(now.getFullYear(), now.getMonth(), 1);
+        break;
     }
-    case 'all':
-      start = new Date(0);
-      end = new Date();
-      break;
-    case 'year':
-      start = new Date(now.getFullYear() - 1, now.getMonth() + 1, 1);
-      break;
-    case 'month':
-    default:
-      start = new Date(now.getFullYear(), now.getMonth(), 1);
-      break;
   }
 
   const categories = await Categoria.findAll({ attributes: ['id', 'name'] });

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -22,12 +22,16 @@ const ranges = [
   { value: 'week', label: 'Esta semana' },
   { value: 'year', label: 'Último año' },
   { value: 'all', label: 'Todo' },
+  { value: 'select', label: 'Seleccionar mes' },
 ];
 
 export default function Dashboard() {
   const { user } = useAuth();
   const categories = useCategories();
   const [range, setRange] = useState('month');
+  const [customMonth, setCustomMonth] = useState(
+    () => new Date().toISOString().slice(0, 7)
+  );
   const [category, setCategory] = useState('all');
   const currency = user?.default_currency_code || 'MXN';
   const formatCurrency = (v) =>
@@ -35,7 +39,8 @@ export default function Dashboard() {
       style: 'currency',
       currency,
     }).format(v);
-  const report = useReport(range, category, currency);
+  const effectiveRange = range === 'select' ? customMonth : range;
+  const report = useReport(effectiveRange, category, currency);
   const table = useSummaryTable(category === 'all', currency);
   const [hoverCol, setHoverCol] = useState(null);
 
@@ -307,6 +312,14 @@ export default function Dashboard() {
             </option>
           ))}
         </select>
+        {range === 'select' && (
+          <input
+            type='month'
+            className='text-black p-1 rounded'
+            value={customMonth}
+            onChange={(e) => setCustomMonth(e.target.value)}
+          />
+        )}
       </div>
       {content}
       {category === 'all' && table && (


### PR DESCRIPTION
## Summary
- support specifying a month string in report service
- expose month picker input in dashboard
- document implemented todo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c7bef1aa08325b1a3db18d51815d1