### PR TITLE
Add month picker range to dashboard

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,4 +13,4 @@
 - [x] Agregar feature: pago dividido entre dos
 - [ ] Página HTTPS
 - [ ] Agregar vista de calendario en fecha de registro gasto
-- [ ] Agregar vista de "Seleccionar mes"
+- [x] Agregar vista de "Seleccionar mes"

--- a/back/controllers/reports.controller.js
+++ b/back/controllers/reports.controller.js
@@ -5,9 +5,9 @@ import {
 } from '../services/reportService.js';
 
 export async function summaryController(req, res) {
-  const { range = 'month', currency = 'MXN' } = req.query;
+  const { range = 'month', currency = 'MXN', month } = req.query;
   try {
-    const data = await getSummary(range, currency);
+    const data = await getSummary(range, currency, month);
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -15,10 +15,10 @@ export async function summaryController(req, res) {
 }
 
 export async function categoryController(req, res) {
-  const { range = 'month', currency = 'MXN' } = req.query;
+  const { range = 'month', currency = 'MXN', month } = req.query;
   const { id } = req.params;
   try {
-    const data = await getCategoryDetail(id, range, currency);
+    const data = await getCategoryDetail(id, range, currency, month);
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/back/services/reportService.js
+++ b/back/services/reportService.js
@@ -18,10 +18,17 @@ function convert(amount, from, to, rates) {
   return to === 'MXN' ? toMXN : toMXN * rates[to];
 }
 
-export async function getSummary(range = 'month', currency = 'MXN') {
+export async function getSummary(range = 'month', currency = 'MXN', monthStr) {
   const now = new Date();
+  if (range === 'custom' && monthStr) {
+    const [y, m] = monthStr.split('-').map(Number);
+    if (!Number.isNaN(y) && !Number.isNaN(m)) {
+      now.setFullYear(y);
+      now.setMonth(m - 1);
+    }
+  }
   let start;
-  let end = new Date();
+  let end = new Date(now);
 
   switch (range) {
     case 'week': {
@@ -39,6 +46,10 @@ export async function getSummary(range = 'month', currency = 'MXN') {
       break;
     case 'year':
       start = new Date(now.getFullYear() - 1, now.getMonth() + 1, 1);
+      break;
+    case 'custom':
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
+      end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
       break;
     case 'month':
     default:
@@ -133,8 +144,13 @@ export async function getSummary(range = 'month', currency = 'MXN') {
   };
 }
 
-export async function getCategoryDetail(id, range = 'month', currency = 'MXN') {
-  const summary = await getSummary(range, currency);
+export async function getCategoryDetail(
+  id,
+  range = 'month',
+  currency = 'MXN',
+  monthStr
+) {
+  const summary = await getSummary(range, currency, monthStr);
   const cat = summary.categories.find((c) => c.id === Number(id));
   if (!cat) throw new Error('Categoria no encontrada');
   const expenses = summary.expenses.filter((e) => e.category_id === Number(id));

--- a/front/src/components/Dashboard.jsx
+++ b/front/src/components/Dashboard.jsx
@@ -22,6 +22,7 @@ const ranges = [
   { value: 'week', label: 'Esta semana' },
   { value: 'year', label: 'Último año' },
   { value: 'all', label: 'Todo' },
+  { value: 'custom', label: 'Elegir mes' },
 ];
 
 export default function Dashboard() {
@@ -29,13 +30,16 @@ export default function Dashboard() {
   const categories = useCategories();
   const [range, setRange] = useState('month');
   const [category, setCategory] = useState('all');
+  const [month, setMonth] = useState(() =>
+    new Date().toISOString().slice(0, 7)
+  );
   const currency = user?.default_currency_code || 'MXN';
   const formatCurrency = (v) =>
     new Intl.NumberFormat('es', {
       style: 'currency',
       currency,
     }).format(v);
-  const report = useReport(range, category, currency);
+  const report = useReport(range, category, currency, range === 'custom' ? month : undefined);
   const table = useSummaryTable(category === 'all', currency);
   const [hoverCol, setHoverCol] = useState(null);
 
@@ -307,6 +311,14 @@ export default function Dashboard() {
             </option>
           ))}
         </select>
+        {range === 'custom' && (
+          <input
+            type='month'
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className='text-black p-1 rounded'
+          />
+        )}
       </div>
       {content}
       {category === 'all' && table && (

--- a/front/src/hooks/useReport.js
+++ b/front/src/hooks/useReport.js
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 import { fetchReport } from '../services/api.js';
 
-export default function useReport(range, category, currency) {
+export default function useReport(range, category, currency, month) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
     let active = true;
     setData(null); // reset while fetching new data
-    fetchReport(range, category, currency)
+    fetchReport(range, category, currency, month)
       .then((d) => {
         if (active) setData(d);
       })
@@ -15,7 +15,7 @@ export default function useReport(range, category, currency) {
     return () => {
       active = false;
     };
-  }, [range, category, currency]);
+  }, [range, category, currency, month]);
 
   return data;
 }

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -84,11 +84,17 @@ export async function createExpense(data) {
   return res.json();
 }
 
-export async function fetchReport(range = 'month', category = 'all', currency = 'MXN') {
+export async function fetchReport(
+  range = 'month',
+  category = 'all',
+  currency = 'MXN',
+  month
+) {
+  const monthParam = range === 'custom' && month ? `&month=${month}` : '';
   const url =
     category === 'all'
-      ? `${REPORT_URL}/summary?range=${range}&currency=${currency}`
-      : `${REPORT_URL}/category/${category}?range=${range}&currency=${currency}`;
+      ? `${REPORT_URL}/summary?range=${range}${monthParam}&currency=${currency}`
+      : `${REPORT_URL}/category/${category}?range=${range}${monthParam}&currency=${currency}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to fetch report');
   return res.json();


### PR DESCRIPTION
## Summary
- allow choosing a month in dashboard
- fetch reports by month via new API support
- add `month` query parameter handling on the backend
- mark TODO as done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c7bef1aa08325b1a3db18d51815d1