### PR TITLE
feat: show status modal when saving expense

### DIFF
--- a/front/src/components/ExpenseForm.jsx
+++ b/front/src/components/ExpenseForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import CustomInput from './CustomInput.jsx';
 import CustomButton from './CustomButton.jsx';
 import CustomSelect from './CustomSelect.jsx';
+import StatusModal from './StatusModal.jsx';
 import useCurrencies from '../hooks/useCurrencies.js';
 import useCategories from '../hooks/useCategories.js';
 import { createExpense } from '../services/api.js';
@@ -26,8 +27,7 @@ export default function ExpenseForm() {
   const [shared, setShared] = useState(false);
   const [recurrenceType, setRecurrenceType] = useState('monthly');
   const [endDate, setEndDate] = useState('');
-  const [message, setMessage] = useState(null);
-  const [error, setError] = useState(null);
+  const [status, setStatus] = useState(null);
 
   useEffect(() => {
     if (!currency && currencies.length > 0) {
@@ -43,8 +43,7 @@ export default function ExpenseForm() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError(null);
-    setMessage(null);
+    setStatus('loading');
     try {
       const numericAmount = parseFloat(amount);
       const payload = {
@@ -58,13 +57,13 @@ export default function ExpenseForm() {
         recurrence_end_date: recurring ? endDate || null : null,
       };
       await createExpense(payload);
-      setMessage('Gasto registrado');
+      setStatus('success');
       setAmount('');
       setDescription('');
       setEndDate('');
     } catch (err) {
       console.error(err);
-      setError('No se pudo registrar el gasto');
+      setStatus('error');
     }
   };
 
@@ -76,9 +75,8 @@ export default function ExpenseForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit} noValidate>
-      {error && <p className='text-red-500 mb-2'>{error}</p>}
-      {message && <p className='text-green-500 mb-2'>{message}</p>}
+    <>
+      <form onSubmit={handleSubmit} noValidate>
       <CustomInput
         name='amount'
         id='amount'
@@ -171,9 +169,12 @@ export default function ExpenseForm() {
           </CustomSelect>
         </>
       )}
-      <CustomButton type='submit' isPrimary>
+      <CustomButton type='submit' isPrimary disabled={status === 'loading'}>
         Guardar
       </CustomButton>
-    </form>
+      </form>
+      <StatusModal status={status} onClose={() => setStatus(null)} />
+    </>
   );
 }
+

--- a/front/src/components/StatusModal.jsx
+++ b/front/src/components/StatusModal.jsx
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import CustomButton from './CustomButton.jsx';
+
+export default function StatusModal({ status, onClose }) {
+  if (!status) return null;
+
+  const isLoading = status === 'loading';
+  let message = 'Registrando gasto..';
+  if (status === 'success') message = 'Gasto registrado';
+  if (status === 'error') message = 'No se pudo registrar el gasto';
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-[var(--md-sys-color-surface)] text-center p-6 rounded shadow-lg">
+        {isLoading && <div className="spinner mx-auto mb-4"></div>}
+        <p
+          className={`mb-4 ${
+            status === 'success'
+              ? 'text-green-500'
+              : status === 'error'
+                ? 'text-red-500'
+                : ''
+          }`}
+        >
+          {message}
+        </p>
+        {!isLoading && (
+          <CustomButton isPrimary onClick={onClose}>
+            Aceptar
+          </CustomButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+StatusModal.propTypes = {
+  status: PropTypes.oneOf([null, 'loading', 'success', 'error']),
+  onClose: PropTypes.func,
+};
+

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -84,3 +84,19 @@ textarea {
 .crosshair-table .col-hover {
   background-color: rgba(144, 202, 249, 0.2);
 }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  border: 4px solid var(--md-sys-color-outline);
+  border-top-color: var(--md-sys-color-primary);
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  animation: spin 1s linear infinite;
+}
+


### PR DESCRIPTION
## Summary
- show animated modal while registering an expense and report success or failure
- disable form submission during save
- add spinner styles

## Testing
- `npm run lint --prefix front`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689990152a3c8325a089879ac78d9235