### PR TITLE
Disable new account registration

### DIFF
--- a/back/controllers/auth.controller.js
+++ b/back/controllers/auth.controller.js
@@ -1,19 +1,19 @@
-import { loginUser, registerUser } from '../services/authService.js';
+import { loginUser /*, registerUser */ } from '../services/authService.js';
 
 export function ping(req, res) {
   res.json({ message: 'pong' });
 }
 
-export async function register(req, res) {
-  try {
-    const user = await registerUser(req.body);
-    // remove password hash
-    delete user.password_hash;
-    res.json(user);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-}
+// export async function register(req, res) {
+//   try {
+//     const user = await registerUser(req.body);
+//     // remove password hash
+//     delete user.password_hash;
+//     res.json(user);
+//   } catch (err) {
+//     res.status(400).json({ error: err.message });
+//   }
+// }
 
 export async function login(req, res) {
   try {

--- a/back/routes/auth.routes.js
+++ b/back/routes/auth.routes.js
@@ -1,10 +1,10 @@
 import { Router } from 'express';
-import { ping, register, login } from '../controllers/auth.controller.js';
+import { ping, /* register, */ login } from '../controllers/auth.controller.js';
 
 const router = Router();
 
 router.get('/ping', ping);
-router.post('/register', register);
+// router.post('/register', register);
 router.post('/login', login);
 
 export default router;

--- a/back/services/authService.js
+++ b/back/services/authService.js
@@ -1,15 +1,15 @@
 import bcrypt from 'bcrypt';
 import { Usuario } from '../models/usuario.model.js';
 
-export async function registerUser({ username, password, default_currency_code }) {
-  const existing = await Usuario.findOne({ where: { username } });
-  if (existing) {
-    throw new Error('Username already exists');
-  }
-  const password_hash = await bcrypt.hash(password, 10);
-  const user = await Usuario.create({ username, password_hash, default_currency_code });
-  return user.toJSON();
-}
+// export async function registerUser({ username, password, default_currency_code }) {
+//   const existing = await Usuario.findOne({ where: { username } });
+//   if (existing) {
+//     throw new Error('Username already exists');
+//   }
+//   const password_hash = await bcrypt.hash(password, 10);
+//   const user = await Usuario.create({ username, password_hash, default_currency_code });
+//   return user.toJSON();
+// }
 
 export async function loginUser({ username, password }) {
   const user = await Usuario.findOne({ where: { username } });

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -1,19 +1,14 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import LoginPage from './pages/LoginPage.jsx';
-import RegisterPage from './pages/RegisterPage.jsx';
+// import RegisterPage from './pages/RegisterPage.jsx';
 import HomePage from './pages/HomePage.jsx';
 
 function Content() {
   const { user } = useAuth();
-  const [showRegister, setShowRegister] = useState(false);
 
   if (!user) {
-    return showRegister ? (
-      <RegisterPage onSwitch={() => setShowRegister(false)} />
-    ) : (
-      <LoginPage onSwitch={() => setShowRegister(true)} />
-    );
+    return <LoginPage />;
   }
 
   return <HomePage />;

--- a/front/src/context/AuthContext.jsx
+++ b/front/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useContext, useEffect } from 'react';
-import { loginUser, registerUser, updateUserCurrency } from '../services/api.js';
+import { loginUser, /* registerUser, */ updateUserCurrency } from '../services/api.js';
 
 const AuthContext = createContext(null);
 
@@ -28,10 +28,11 @@ export function AuthProvider({ children }) {
     }
   };
 
-  const register = async (data) => {
-    const u = await registerUser(data);
-    setUser(u);
-  };
+
+  // const register = async (data) => {
+  //   const u = await registerUser(data);
+  //   setUser(u);
+  // };
 
   const changeCurrency = async (code) => {
     if (!user) return;
@@ -48,7 +49,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout, changeCurrency }}>
+    <AuthContext.Provider value={{ user, login, logout, changeCurrency }}>
       {children}
     </AuthContext.Provider>
   );

--- a/front/src/pages/LoginPage.jsx
+++ b/front/src/pages/LoginPage.jsx
@@ -6,7 +6,7 @@ import CustomButton from '../components/CustomButton.jsx';
 import AuthCardError from '../components/auth/AuthCardError.jsx';
 import { FaUser, FaLock } from 'react-icons/fa';
 
-export default function LoginPage({ onSwitch }) {
+export default function LoginPage() {
   const { login } = useAuth();
   const [credentials, setCredentials] = useState({ username: '', password: '' });
   const [remember, setRemember] = useState(false);
@@ -74,7 +74,7 @@ export default function LoginPage({ onSwitch }) {
           />
           <span>Recuérdame</span>
         </label>
-        <p className='text-sm text-gray-600 mb-4'>
+        {/* <p className='text-sm text-gray-600 mb-4'>
           ¿No tienes cuenta?{' '}
           <button
             type='button'
@@ -83,7 +83,7 @@ export default function LoginPage({ onSwitch }) {
           >
             Regístrate
           </button>
-        </p>
+        </p> */}
         <CustomButton type='submit' isPrimary>
           Iniciar sesión
         </CustomButton>

--- a/front/src/pages/RegisterPage.jsx
+++ b/front/src/pages/RegisterPage.jsx
@@ -1,84 +1,84 @@
-import React, { useState } from 'react';
-import { useAuth } from '../context/AuthContext.jsx';
-import AuthCard from '../components/auth/AuthCard.jsx';
-import CustomInput from '../components/CustomInput.jsx';
-import CustomSelect from '../components/CustomSelect.jsx';
-import CustomButton from '../components/CustomButton.jsx';
-import AuthCardError from '../components/auth/AuthCardError.jsx';
-import { FaUser, FaLock, FaMoneyBill } from 'react-icons/fa';
-import useCurrencies from '../hooks/useCurrencies.js';
+// import React, { useState } from 'react';
+// import { useAuth } from '../context/AuthContext.jsx';
+// import AuthCard from '../components/auth/AuthCard.jsx';
+// import CustomInput from '../components/CustomInput.jsx';
+// import CustomSelect from '../components/CustomSelect.jsx';
+// import CustomButton from '../components/CustomButton.jsx';
+// import AuthCardError from '../components/auth/AuthCardError.jsx';
+// import { FaUser, FaLock, FaMoneyBill } from 'react-icons/fa';
+// import useCurrencies from '../hooks/useCurrencies.js';
 
-export default function RegisterPage({ onSwitch }) {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const currencies = useCurrencies();
-  const [currency, setCurrency] = useState('');
+// export default function RegisterPage({ onSwitch }) {
+//   const [username, setUsername] = useState('');
+//   const [password, setPassword] = useState('');
+//   const currencies = useCurrencies();
+//   const [currency, setCurrency] = useState('');
 
-  React.useEffect(() => {
-    if (!currency && currencies.length > 0) {
-      setCurrency(currencies[0]);
-    }
-  }, [currencies]);
-  const { register } = useAuth();
-  const [error, setError] = useState(null);
+//   React.useEffect(() => {
+//    if (!currency && currencies.length > 0) {
+//      setCurrency(currencies[0]);
+//    }
+//  }, [currencies]);
+//   const { register } = useAuth();
+//   const [error, setError] = useState(null);
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setError(null);
-    if (!username || !password || !currency) {
-      setError('Completa todos los campos.');
-      return;
-    }
-    try {
-      await register({ username, password, default_currency_code: currency });
-    } catch (err) {
-      console.error(err);
-      setError('Registration failed');
-    }
-  };
+//   const handleSubmit = async (e) => {
+//     e.preventDefault();
+//     setError(null);
+//     if (!username || !password || !currency) {
+//       setError('Completa todos los campos.');
+//       return;
+//     }
+//     try {
+//       await register({ username, password, default_currency_code: currency });
+//     } catch (err) {
+//       console.error(err);
+//       setError('Registration failed');
+//     }
+//   };
 
-  return (
-    <AuthCard title='Registro' description='Crea tu cuenta para comenzar' showBackButton onBack={onSwitch}>
-      {error && <AuthCardError>{error}</AuthCardError>}
-      <form onSubmit={handleSubmit} noValidate>
-        <CustomInput
-          name='username'
-          id='reg-username'
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          placeholder='Nombre de usuario'
-          icon={<FaUser />}
-          required
-        >
-          Usuario
-        </CustomInput>
-        <CustomInput
-          name='password'
-          id='reg-password'
-          type='password'
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder='******'
-          icon={<FaLock />}
-          required
-        >
-          Contraseña
-        </CustomInput>
-        <CustomSelect
-          name='currency'
-          id='reg-currency'
-          value={currency}
-          onChange={(e) => setCurrency(e.target.value)}
-          options={currencies}
-          icon={<FaMoneyBill />}
-          required
-        >
-          Moneda predeterminada
-        </CustomSelect>
-        <CustomButton type='submit' isPrimary>
-          Registrarse
-        </CustomButton>
-      </form>
-    </AuthCard>
-  );
-}
+//   return (
+//     <AuthCard title='Registro' description='Crea tu cuenta para comenzar' showBackButton onBack={onSwitch}>
+//       {error && <AuthCardError>{error}</AuthCardError>}
+//       <form onSubmit={handleSubmit} noValidate>
+//         <CustomInput
+//           name='username'
+//           id='reg-username'
+//           value={username}
+//           onChange={(e) => setUsername(e.target.value)}
+//           placeholder='Nombre de usuario'
+//           icon={<FaUser />}
+//           required
+//         >
+//           Usuario
+//         </CustomInput>
+//         <CustomInput
+//           name='password'
+//           id='reg-password'
+//           type='password'
+//           value={password}
+//           onChange={(e) => setPassword(e.target.value)}
+//           placeholder='******'
+//           icon={<FaLock />}
+//           required
+//         >
+//           Contraseña
+//         </CustomInput>
+//         <CustomSelect
+//           name='currency'
+//           id='reg-currency'
+//           value={currency}
+//           onChange={(e) => setCurrency(e.target.value)}
+//           options={currencies}
+//           icon={<FaMoneyBill />}
+//           required
+//         >
+//           Moneda predeterminada
+//         </CustomSelect>
+//         <CustomButton type='submit' isPrimary>
+//           Registrarse
+//         </CustomButton>
+//       </form>
+//     </AuthCard>
+//   );
+// }

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -6,15 +6,15 @@ const DIVISA_URL = '/api/divisas';
 const EXPENSE_URL = '/api/gastos';
 const REPORT_URL = '/api/reports';
 
-export async function registerUser(data) {
-  const res = await fetch(`${API_URL}/register`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-  if (!res.ok) throw new Error('Failed registration');
-  return res.json();
-}
+// export async function registerUser(data) {
+//   const res = await fetch(`${API_URL}/register`, {
+//     method: 'POST',
+//     headers: { 'Content-Type': 'application/json' },
+//     body: JSON.stringify(data),
+//   });
+//   if (!res.ok) throw new Error('Failed registration');
+//   return res.json();
+// }
 
 export async function loginUser(data) {
   const res = await fetch(`${API_URL}/login`, {


### PR DESCRIPTION
## Summary
- comment out registration route and logic in backend auth modules to prevent user creation
- remove registration page and related API calls in frontend so only login remains

## Testing
- `cd back && npm test`
- `cd front && npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b85d6a588325a983f140587c8899